### PR TITLE
fix: importing polygon points

### DIFF
--- a/src/encord_active/lib/model_predictions/writer.py
+++ b/src/encord_active/lib/model_predictions/writer.py
@@ -65,7 +65,10 @@ def polyobj_to_nparray(o: dict, width: int, height: int) -> np.ndarray:
 
 def points_to_mask(points: np.ndarray, width: int, height: int):
     mask = np.zeros((height, width), dtype=np.uint8)
-    mask = cv2.fillPoly(mask, [(points * np.array([[width, height]])).astype(int)], 1)  # type: ignore
+    if np.issubdtype(points.dtype, np.floating) and points.max() <= 1.0:
+        points *= np.array([[width, height]])
+
+    mask = cv2.fillPoly(mask, [(points).astype(int)], 1)  # type: ignore
     return mask
 
 


### PR DESCRIPTION
Fixing `points_to_mask` function to both handle normalized and absolute values.