### PR TITLE
Refactor: enforce project file structure usage

### DIFF
--- a/src/encord_active/app/common/state.py
+++ b/src/encord_active/app/common/state.py
@@ -10,7 +10,7 @@ from encord_active.lib.db.merged_metrics import MergedMetrics
 from encord_active.lib.db.tags import Tag, Tags
 from encord_active.lib.metrics.utils import MetricData
 from encord_active.lib.model_predictions.reader import LabelSchema, OntologyObjectJSON
-from encord_active.lib.project.project_file_structure import ProjectFileStructure
+from encord_active.lib.project import ProjectFileStructure
 
 GLOBAL_STATE = "global_state"
 

--- a/src/encord_active/cli/imports.py
+++ b/src/encord_active/cli/imports.py
@@ -25,7 +25,7 @@ def import_predictions(
     [bold]Imports[/bold] a predictions file. The predictions should be using the `Prediction` model and be stored in a pkl file.
     If `--coco` option is specified the file should be a json following the coco results format. :brain:
     """
-    from encord_active.lib.project.project import Project
+    from encord_active.lib.project import Project
 
     project = Project(target)
 

--- a/src/encord_active/lib/common/iterator.py
+++ b/src/encord_active/lib/common/iterator.py
@@ -14,7 +14,7 @@ from encord.orm.label_log import LabelLog
 from loguru import logger
 from tqdm import tqdm
 
-from encord_active.lib.project.project import Project
+from encord_active.lib.project import Project
 
 
 class Iterator(Sized):

--- a/src/encord_active/lib/common/iterator.py
+++ b/src/encord_active/lib/common/iterator.py
@@ -92,7 +92,7 @@ class DatasetIterator(Iterator):
 
                     image_path = None
                     if self.project.image_paths:
-                        image_folder = self.cache_dir / "data" / self.label_hash / "images"
+                        image_folder = self.project.file_structure.label_row_structure(self.label_hash).images_dir
                         image_path = next(image_folder.glob(f"{self.du_hash}_{frame_sequence}.*"), None)
 
                     yield fake_data_unit, image_path

--- a/src/encord_active/lib/dataset/balance.py
+++ b/src/encord_active/lib/dataset/balance.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from encord_active.lib.coco.encoder import generate_coco_file
 from encord_active.lib.metrics.utils import MetricData, load_metric_dataframe
-from encord_active.lib.project.project_file_structure import ProjectFileStructure
+from encord_active.lib.project import ProjectFileStructure
 
 
 def balance_dataframe(selected_metrics: List[MetricData], partition_sizes: Dict[str, int], seed: int) -> pd.DataFrame:

--- a/src/encord_active/lib/db/connection.py
+++ b/src/encord_active/lib/db/connection.py
@@ -2,7 +2,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-from encord_active.lib.project.project_file_structure import ProjectFileStructure
+from encord_active.lib.project import ProjectFileStructure
 
 
 class DBConnection:

--- a/src/encord_active/lib/db/predictions.py
+++ b/src/encord_active/lib/db/predictions.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, validator
 from encord_active.lib.metrics.execute import run_all_prediction_metrics
 from encord_active.lib.model_predictions.iterator import PredictionIterator
 from encord_active.lib.model_predictions.writer import PredictionWriter
-from encord_active.lib.project.project import Project
+from encord_active.lib.project import Project
 
 RelativeFloat = Annotated[float, Field(ge=0, le=1)]
 

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -84,7 +84,7 @@ class EncordActions:
 
             if label_row_hash not in uploaded_label_rows:
                 if label_row["data_type"] == DataType.IMAGE.value:
-                    image_path = list(label_row_structure.images.glob(f"{data_unit_hash}.*"))[0]
+                    image_path = list(label_row_structure.images_dir.glob(f"{data_unit_hash}.*"))[0]
                     uploaded_image: Image = dataset.upload_image(
                         file_path=image_path, title=label_row["data_units"][data_unit_hash]["data_title"]
                     )
@@ -99,7 +99,7 @@ class EncordActions:
                     image_names = []
                     if len(label_hash_to_data_units[label_row_hash]) > 0:
                         for data_unit in label_hash_to_data_units[label_row_hash]:
-                            img_path = list(label_row_structure.images.glob(f"{data_unit}.*"))[0]
+                            img_path = list(label_row_structure.images_dir.glob(f"{data_unit}.*"))[0]
                             image_paths.append(img_path.as_posix())
                             image_names.append(img_path.name)
 
@@ -113,7 +113,7 @@ class EncordActions:
                         )
 
                 elif label_row["data_type"] == DataType.VIDEO.value:
-                    video_path = list(label_row_structure.images.glob(f"{data_unit_hash}.*"))[0].as_posix()
+                    video_path = list(label_row_structure.images_dir.glob(f"{data_unit_hash}.*"))[0].as_posix()
 
                     # Unfortunately the following function does not return metadata related to the uploaded items
                     dataset.upload_video(

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -11,7 +11,7 @@ from encord.utilities.label_utilities import construct_answer_dictionaries
 from tqdm import tqdm
 
 from encord_active.lib.common.utils import fetch_project_meta
-from encord_active.lib.project.project_file_structure import ProjectFileStructure
+from encord_active.lib.project import ProjectFileStructure
 
 
 class DatasetCreationResult(NamedTuple):

--- a/src/encord_active/lib/model_predictions/importers.py
+++ b/src/encord_active/lib/model_predictions/importers.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from encord_active.lib.model_predictions.writer import PredictionWriter
 from encord_active.lib.project.project import download_all_label_rows
+from encord_active.lib.project.project_file_structure import ProjectFileStructure
 
 logger = logging.getLogger(__name__)
 KITTI_COLUMNS = [
@@ -106,7 +107,7 @@ def import_mask_predictions(
 
 
     """
-    label_rows = download_all_label_rows(project, cache_dir=cache_dir)
+    label_rows = download_all_label_rows(project, ProjectFileStructure(cache_dir))
     du_hash_lookup: Dict[str, Tuple[str, int]] = {}
 
     if not class_map:

--- a/src/encord_active/lib/model_predictions/importers.py
+++ b/src/encord_active/lib/model_predictions/importers.py
@@ -18,8 +18,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from encord_active.lib.model_predictions.writer import PredictionWriter
-from encord_active.lib.project.project import download_all_label_rows
-from encord_active.lib.project.project_file_structure import ProjectFileStructure
+from encord_active.lib.project import Project, ProjectFileStructure
 
 logger = logging.getLogger(__name__)
 KITTI_COLUMNS = [
@@ -107,7 +106,7 @@ def import_mask_predictions(
 
 
     """
-    label_rows = download_all_label_rows(project, ProjectFileStructure(cache_dir))
+    label_rows = Project(cache_dir).from_encord_project(project).label_rows
     du_hash_lookup: Dict[str, Tuple[str, int]] = {}
 
     if not class_map:

--- a/src/encord_active/lib/model_predictions/importers.py
+++ b/src/encord_active/lib/model_predictions/importers.py
@@ -18,7 +18,7 @@ from PIL import Image
 from tqdm import tqdm
 
 from encord_active.lib.model_predictions.writer import PredictionWriter
-from encord_active.lib.project import Project, ProjectFileStructure
+from encord_active.lib.project import Project
 
 logger = logging.getLogger(__name__)
 KITTI_COLUMNS = [

--- a/src/encord_active/lib/model_predictions/iterator.py
+++ b/src/encord_active/lib/model_predictions/iterator.py
@@ -66,9 +66,9 @@ class PredictionIterator(Iterator):
         self.row_cache: List[Tuple[str, str, int, Dict[Any, Any], Optional[Path]]] = []
 
     def get_image_path(self, pred: Series) -> Optional[Path]:
-        img_folder = self.cache_dir / "data" / pred["label_hash"] / "images"
+        images_dir = self.project.file_structure.label_row_structure(pred["label_hash"]).images_dir
         du_hash = pred["du_hash"]
-        image_options = list(img_folder.glob(f"{du_hash}.*"))
+        image_options = list(images_dir.glob(f"{du_hash}.*"))
         if len(image_options) == 1:
             return image_options[0]
         elif len(image_options) > 1:

--- a/src/encord_active/lib/model_predictions/writer.py
+++ b/src/encord_active/lib/model_predictions/writer.py
@@ -14,7 +14,7 @@ from torchvision.ops import box_iou
 from tqdm import tqdm
 
 from encord_active.lib.common.utils import binary_mask_to_rle, rle_iou
-from encord_active.lib.project.project import Project
+from encord_active.lib.project import Project
 
 logger = logging.getLogger(__name__)
 BBOX_KEYS = {"x", "y", "w", "h"}

--- a/src/encord_active/lib/project/__init__.py
+++ b/src/encord_active/lib/project/__init__.py
@@ -1,0 +1,2 @@
+from .project import Project
+from .project_file_structure import LabelRowStructure, ProjectFileStructure

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -5,7 +5,7 @@ import json
 import logging
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import encord.exceptions
 import yaml
@@ -142,91 +142,81 @@ class Project:
         }
 
     def __download_and_save_label_rows(self, encord_project: EncordProject):
-        label_rows = download_all_label_rows(encord_project, cache_dir=self.file_structure.project_dir)
-        download_all_images(label_rows, cache_dir=self.file_structure.project_dir)
+        label_rows = download_all_label_rows(encord_project, self.file_structure)
+        download_all_images(label_rows, self.file_structure)
 
     def __load_label_rows(self):
         self.label_rows = {}
         self.image_paths = {}
         for lr_hash in self.label_row_meta.keys():
-            lr_file_path = self.file_structure.label_row_structure(lr_hash).label_row_file
-            lr_images_dir = self.file_structure.data / lr_hash / "images"
-            if not lr_file_path.is_file() or not lr_images_dir.is_dir():
+            lr_structure = self.file_structure.label_row_structure(lr_hash)
+            if not lr_structure.label_row_file.is_file() or not lr_structure.images_dir.is_dir():
                 logger.warning(
-                    f"Skipping label row <blue>`{lr_hash}`</blue> as no stored content was found for the label row."
+                    f"Skipping label row <blue>`{lr_hash}`</blue> as its content wasn't found in the storage."
                 )
                 continue
-            self.label_rows[lr_hash] = LabelRow(json.loads(lr_file_path.read_text(encoding="utf-8")))
-            self.image_paths[lr_hash] = list(lr_images_dir.iterdir())
+            self.label_rows[lr_hash] = LabelRow(json.loads(lr_structure.label_row_file.read_text(encoding="utf-8")))
+            self.image_paths[lr_hash] = list(lr_structure.images_dir.iterdir())
 
 
-def get_label_row(lr, client, cache_dir, refresh=False) -> Optional[LabelRow]:
-    if isinstance(cache_dir, str):
-        cache_dir = Path(cache_dir)
-
+def get_label_row(
+    lr, project: EncordProject, project_file_structure: ProjectFileStructure, refresh=False
+) -> Optional[LabelRow]:
     if not lr["label_hash"]:
         return None
 
-    cache_pth = cache_dir / "data" / lr["label_hash"] / "label_row.json"
+    lr_structure = project_file_structure.label_row_structure(lr["label_hash"])
+    lr_structure.path.mkdir(parents=True, exist_ok=True)
 
-    if not refresh and cache_pth.is_file():
+    if not refresh and lr_structure.label_row_file.is_file():
         try:
-            with cache_pth.open("r") as f:
-                return LabelRow(json.load(f))
+            return LabelRow(json.loads(lr_structure.label_row_file.read_text(encoding="utf-8")))
         except json.decoder.JSONDecodeError:
             pass
 
     try:
-        lr = client.get_label_row(lr["label_hash"])
+        lr = project.get_label_row(lr["label_hash"])
     except encord.exceptions.UnknownException:
         logger.warning(
-            f"Failed to download label row with label_hash <blue>`{lr['label_hash'][:8]}`</blue> and data_title <blue>`{lr['data_title']}`</blue>"
+            f"Failed to download label row with label_hash <blue>`{lr['label_hash']}`</blue> and data_title <blue>`{lr['data_title']}`</blue>"
         )
         return None
 
-    cache_pth.parent.mkdir(parents=True, exist_ok=True)
-    with cache_pth.open("w") as f:
-        json.dump(lr, f, indent=2)
-
+    lr_structure.label_row_file.write_text(json.dumps(lr, indent=2), encoding="utf-8")
     return lr
 
 
-def download_all_label_rows(client, subset_size: Optional[int] = None, **kwargs) -> Dict[str, LabelRow]:
-    label_rows = list(itertools.islice(filter(lambda x: x["label_hash"], client.label_rows), subset_size))
+def download_all_label_rows(
+    project: EncordProject, project_file_structure: ProjectFileStructure, subset_size: Optional[int] = None, **kwargs
+) -> Dict[str, LabelRow]:
+    label_rows = list(itertools.islice(filter(lambda x: x["label_hash"], project.label_rows), subset_size))
 
     return collect_async(
-        partial(get_label_row, client=client, **kwargs),
+        partial(get_label_row, project=project, project_file_structure=project_file_structure, **kwargs),
         label_rows,
         lambda lr: lr["label_hash"],
         desc="Collecting label rows from Encord SDK.",
     )
 
 
-def download_images_from_data_unit(lr, cache_dir, **kwargs) -> Optional[List[Path]]:
-    if isinstance(cache_dir, str):
-        cache_dir = Path(cache_dir)
-
+def download_images_from_data_unit(lr, project_file_structure: ProjectFileStructure) -> Optional[List[Path]]:
     label_hash = lr.label_hash
 
     if label_hash is None:
         return None
 
-    label_pth = cache_dir / "data" / label_hash
-    label_pth.mkdir(parents=True, exist_ok=True)
+    lr_structure = project_file_structure.label_row_structure(label_hash)
+    lr_structure.path.mkdir(parents=True, exist_ok=True)
 
-    lr_path = label_pth / "label_row.json"
-    if not lr_path.exists():
-        with (label_pth / "label_row.json").open("w") as f:
-            json.dump(lr, f, indent=2)
+    if not lr_structure.label_row_file.exists():
+        lr_structure.label_row_file.write_text(json.dumps(lr, indent=2), encoding="utf-8")
 
-    frame_pth = label_pth / "images"
-
-    frame_pth.mkdir(parents=True, exist_ok=True)
+    lr_structure.images_dir.mkdir(parents=True, exist_ok=True)
     frame_pths: List[Path] = []
     data_units = sorted(lr.data_units.values(), key=lambda du: int(du["data_sequence"]))
     for du in data_units:
         suffix = f".{du['data_type'].split('/')[1]}"
-        out_pth = (frame_pth / du["data_hash"]).with_suffix(suffix)
+        out_pth = (lr_structure.images_dir / du["data_hash"]).with_suffix(suffix)
         out_pth = download_file(du["data_link"], out_pth)
         frame_pths.append(out_pth)
 
@@ -239,9 +229,9 @@ def download_images_from_data_unit(lr, cache_dir, **kwargs) -> Optional[List[Pat
     return frame_pths
 
 
-def download_all_images(label_rows, cache_dir: Union[str, Path], **kwargs) -> Dict[str, List[Path]]:
+def download_all_images(label_rows, project_file_structure: ProjectFileStructure) -> Dict[str, List[Path]]:
     return collect_async(
-        partial(download_images_from_data_unit, cache_dir=cache_dir, **kwargs),
+        partial(download_images_from_data_unit, project_file_structure=project_file_structure),
         label_rows.values(),
         lambda lr: lr.label_hash,
         desc="Collecting frames from label rows.",

--- a/src/encord_active/lib/project/project_file_structure.py
+++ b/src/encord_active/lib/project/project_file_structure.py
@@ -10,7 +10,7 @@ class LabelRowStructure(NamedTuple):
 
 class ProjectFileStructure:
     def __init__(self, project_dir: Path):
-        self.project_dir: Path = project_dir
+        self.project_dir: Path = project_dir.expanduser().resolve()
 
     @property
     def data(self) -> Path:

--- a/src/encord_active/lib/project/project_file_structure.py
+++ b/src/encord_active/lib/project/project_file_structure.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 
 class LabelRowStructure(NamedTuple):
     path: Path
-    images: Path
+    images_dir: Path
     label_row_file: Path
 
 
@@ -46,4 +46,4 @@ class ProjectFileStructure:
 
     def label_row_structure(self, label_hash: str) -> LabelRowStructure:
         path = self.data / label_hash
-        return LabelRowStructure(path, path / "images", path / "label_row.json")
+        return LabelRowStructure(path=path, images_dir=path / "images", label_row_file=path / "label_row.json")


### PR DESCRIPTION
**Context**: Latest addition of `ProjectFileStructure` class allows to declare paths via file system references in `ProjectFileStructure` instead of explicitly declaring how to construct such paths each time they are needed with the subsequent error/bug chances and loss of portability from one project file structure to another. At the time of writing this PR the explicit file structure version is predominant across the codebase and we aim to encapsulate usage of every file system related path through `ProjectFileStructure` class.

This PR starts enforcing `ProjectFileStructure` as the main and only way to access file/dir paths of project's elements (e.g. image, label row json, metadata). The following changes were applied:

- `project_dir` attribute was removed from `Project` class to ensure that every required path related content is accessed via `ProjectFileStructure`.
- Convert explicit paths of project's elements into their `ProjectFileStructure` versions.
- Misc: update `Project` related functions to work with `ProjectFileStructure` and convert their calls from outside the `Project` class to their `Project` instance method call equivalent.
- Misc: update import settings to avoid naming redundancies like `from encord_active.lib.project.project import Project` (after this PR it will look like `from encord_active.lib.project import Project`)
