### PR TITLE
Fix(encoder): tag handling

### DIFF
--- a/src/encord_active/lib/coco/encoder.py
+++ b/src/encord_active/lib/coco/encoder.py
@@ -776,15 +776,18 @@ def df_to_nested_dict(df: pd.DataFrame) -> dict:
         frame_dict = data_dict.setdefault(frame_number, {})
         frame_dict.setdefault("frame-level", {})
 
+        tags = [t.name for t in (row["tags"] if "tags" in row and isinstance(row["tags"], list) else [])]
         if object_hashes is None:  # Frame level metric
             frame_dict.setdefault("frame-level", {}).update(
-                {k: v for k, v in row.items() if k not in ["identifier", "url"] and not pd.isnull(v)}
+                {k: v for k, v in row.items() if k not in ["identifier", "url", "tags"] and not pd.isnull(v)}
             )
+            frame_dict["frame-level"].setdefault("tags", []).extend(tags)
         else:  # Object level metric
             for object_hash in object_hashes:
                 frame_dict.setdefault(object_hash, {}).update(
-                    {k: v for k, v in row.items() if k not in ["identifier", "url"] and not pd.isnull(v)}
+                    {k: v for k, v in row.items() if k not in ["identifier", "url", "tags"] and not pd.isnull(v)}
                 )
+                frame_dict[object_hash].setdefault("tags", []).extend(tags)
     return metrics
 
 


### PR DESCRIPTION
An image/object that has tags is not suited for `pd.isnull(..)` as it compares each tag against null instead of the container of the tags (a list), so tags need to be handled separately.
Also, now the encoding will output tag names instead of the tag class representation. We still need to address the issue of tag names containing emojis added by EA to clean a little more the output json.