### PR TITLE
chore: remove unnecessary statistics in explorer

### DIFF
--- a/src/encord_active/app/common/components/annotator_statistics.py
+++ b/src/encord_active/app/common/components/annotator_statistics.py
@@ -13,6 +13,9 @@ from encord_active.lib.metrics.utils import (
 
 def render_annotator_properties(df: DataFrame[MetricSchema]):
     annotators = get_annotator_level_info(df)
+    if len(annotators) == 0:
+        return
+
     left_col, right_col = st.columns([2, 2])
 
     # 1. Pie Chart

--- a/src/encord_active/app/common/components/label_statistics.py
+++ b/src/encord_active/app/common/components/label_statistics.py
@@ -8,10 +8,11 @@ from encord_active.lib.metrics.utils import MetricSchema
 
 
 def render_dataset_properties(current_df: DataFrame[MetricSchema]):
+    cls_set = natsorted(current_df[MetricSchema.object_class].dropna().unique().tolist())
+    if len(cls_set) == 0:
+        return
+
     dataset_columns = st.columns(3)
-
-    cls_set = natsorted(list(current_df[MetricSchema.object_class].unique()))
-
     dataset_columns[0].metric("Number of labels", current_df.shape[0])
     dataset_columns[1].metric("Number of classes", len(cls_set))
     dataset_columns[2].metric("Number of images", get_unique_data_units_size(current_df))

--- a/src/encord_active/app/data_quality/sub_pages/explorer.py
+++ b/src/encord_active/app/data_quality/sub_pages/explorer.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 import pandas as pd
 import streamlit as st
+from natsort import natsorted
 from pandas import Series
 from pandera.typing import DataFrame
 from streamlit.delta_generator import DeltaGenerator
@@ -56,7 +57,7 @@ class ExplorerPage(Page):
         non_empty_metrics = [
             metric for metric in available_metrics if not load_metric_dataframe(metric, normalize=False).empty
         ]
-        sorted_metrics = sorted(non_empty_metrics, key=lambda i: i.name)
+        sorted_metrics = natsorted(non_empty_metrics, key=lambda i: i.name)
 
         metric_names = list(map(lambda i: i.name, sorted_metrics))
 
@@ -75,28 +76,33 @@ class ExplorerPage(Page):
         get_state().selected_metric = selected_metric
 
         normalize = selected_metric.meta.get("score_normalization", get_state().normalize_metrics)
-        df = load_metric_dataframe(selected_metric, normalize=normalize)
+        df: DataFrame[MetricSchema] = load_metric_dataframe(selected_metric, normalize=normalize)
 
         if df.shape[0] <= 0:
             return
 
-        class_set = sorted(list(df["object_class"].unique()))
+        class_set = natsorted(df[MetricSchema.object_class].dropna().unique().tolist())
         with col2:
-            selected_classes = st.multiselect("Filter by class", class_set)
+            selected_classes = None
+            if len(class_set) > 0:
+                selected_classes = st.multiselect("Filter by class", class_set)
 
-        is_class_selected = df.shape[0] * [True] if not selected_classes else df["object_class"].isin(selected_classes)
+        is_class_selected = (
+            df.shape[0] * [True] if not selected_classes else df[MetricSchema.object_class].isin(selected_classes)
+        )
         df_class_selected: DataFrame[MetricSchema] = df[is_class_selected]
 
         annotators = get_annotator_level_info(df_class_selected)
-        annotator_set = sorted(annotators.keys())
-
+        annotator_set = natsorted(annotators.keys())
         with col3:
-            selected_annotators = st.multiselect("Filter by annotator", annotator_set)
+            selected_annotators = None
+            if len(annotator_set) > 0:
+                selected_annotators = st.multiselect("Filter by annotator", annotator_set)
 
         annotator_selected = (
             df_class_selected.shape[0] * [True]
             if not selected_annotators
-            else df_class_selected["annotator"].isin(selected_annotators)
+            else df_class_selected[MetricSchema.annotator].isin(selected_annotators)
         )
 
         self.row_col_settings_in_sidebar()

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -127,7 +127,7 @@ class AnnotatorInfo(TypedDict):
 
 
 def get_annotator_level_info(df: DataFrame[MetricSchema]) -> dict[str, AnnotatorInfo]:
-    annotator_set: List[str] = natsorted(list(df[MetricSchema.annotator].unique()))
+    annotator_set: List[str] = natsorted(df[MetricSchema.annotator].dropna().unique().tolist())
     annotators: Dict[str, AnnotatorInfo] = {}
     for annotator in annotator_set:
         annotators[annotator] = AnnotatorInfo(


### PR DESCRIPTION
With this PR, no multiselect nor statistics related to `object_class`/`annotator` will be shown if `object_class` or `annotator` information are undefined in the data.
Also, `NaN` values are not shown as an option in the multiselects related to `object_class` and `annotator`.

These changes effectively remove `object_class` and `annotator` multiselects and statistics in the data quality explorer and as a side effect in some metrics, like `Frame Object Density`, in the label quality explorer where no `object_class` nor `annotator` are available.