### PR TITLE
refactor: remove score normalisation from metric definition

### DIFF
--- a/src/encord_active/lib/metrics/geometric/hu_static.py
+++ b/src/encord_active/lib/metrics/geometric/hu_static.py
@@ -38,7 +38,6 @@ class HuMomentsStatic(Metric):
     LONG_DESCRIPTION = r"""Computes the Euclidean distance between the polygons'
     [Hu moments](https://en.wikipedia.org/wiki/Image_moment) for each class and
     the prototypical class moments."""
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.GEOMETRIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = [AnnotationType.OBJECT.POLYGON]

--- a/src/encord_active/lib/metrics/geometric/hu_temporal.py
+++ b/src/encord_active/lib/metrics/geometric/hu_temporal.py
@@ -51,7 +51,6 @@ class HuMomentsTemporalMetric(Metric):
     LONG_DESCRIPTION = r"""Ranks objects by how similar they are to their instances in previous frames
 based on [Hu moments](https://en.wikipedia.org/wiki/Image_moment). The more an object's shape changes,
 the lower its score will be."""
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.GEOMETRIC
     DATA_TYPE = DataType.SEQUENCE
     ANNOTATION_TYPE = [AnnotationType.OBJECT.POLYGON]

--- a/src/encord_active/lib/metrics/geometric/object_size.py
+++ b/src/encord_active/lib/metrics/geometric/object_size.py
@@ -32,7 +32,6 @@ class RelativeObjectAreaMetric(Metric):
     TITLE = "Object Area - Relative"
     SHORT_DESCRIPTION = "Computes object area as a percentage of total image area"
     LONG_DESCRIPTION = r"""Computes object area as a percentage of total image area."""
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.GEOMETRIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = [
@@ -62,7 +61,6 @@ class OccupiedTotalAreaMetric(Metric):
     TITLE = "Frame object density"
     SHORT_DESCRIPTION = "Computes the percentage of image area that's occupied by objects"
     LONG_DESCRIPTION = r"""Computes the percentage of image area that's occupied by objects."""
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.GEOMETRIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = [

--- a/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
+++ b/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
@@ -20,7 +20,6 @@ class OcclusionDetectionOnVideo(Metric):
     SHORT_DESCRIPTION = "Tracks objects and detect outliers"
     LONG_DESCRIPTION = r"""This metric collects information related to object size and aspect ratio for each track
  and find outliers among them."""
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.GEOMETRIC
     DATA_TYPE = DataType.SEQUENCE
     ANNOTATION_TYPE = [AnnotationType.OBJECT.BOUNDING_BOX]

--- a/src/encord_active/lib/metrics/heuristic/_annotation_time.py
+++ b/src/encord_active/lib/metrics/heuristic/_annotation_time.py
@@ -21,7 +21,6 @@ If no logs are available for a particular object, it will get score 0."""
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.ALL
-    SCORE_NORMALIZATION = True
 
     def execute(self, iterator: Iterator, writer: CSVMetricWriter):
         found_any = False

--- a/src/encord_active/lib/metrics/heuristic/img_features.py
+++ b/src/encord_active/lib/metrics/heuristic/img_features.py
@@ -38,7 +38,6 @@ class ContrastMetric(Metric):
 
 Contrast is computed as the standard deviation of the pixel values.
 """
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.NONE
@@ -53,7 +52,6 @@ Contrast is computed as the standard deviation of the pixel values.
 
 class Wrapper:  # we can't have a non-default-constructible Metric implementation at module level
     class ColorMetric(Metric):
-        SCORE_NORMALIZATION = True
         METRIC_TYPE = MetricType.HEURISTIC
         DATA_TYPE = DataType.IMAGE
         ANNOTATION_TYPE = AnnotationType.NONE
@@ -167,7 +165,6 @@ class BrightnessMetric(Metric):
 
 Brightness is computed as the average (normalized) pixel value across each image.
 """
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.NONE
@@ -193,7 +190,6 @@ image.
 score = cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.NONE
@@ -219,7 +215,6 @@ image. Note that this is $1 - \text{sharpness}$.
 score = 1 - cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.NONE

--- a/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
+++ b/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
@@ -36,7 +36,6 @@ class ErrorStore:
 
 class MissingObjectsMetric(Metric):
     TITLE = "Missing Objects and Broken Tracks"
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.HEURISTIC
     DATA_TYPE = DataType.SEQUENCE
     ANNOTATION_TYPE = [AnnotationType.OBJECT.BOUNDING_BOX, AnnotationType.OBJECT.POLYGON]

--- a/src/encord_active/lib/metrics/metric.py
+++ b/src/encord_active/lib/metrics/metric.py
@@ -42,7 +42,6 @@ class MetricMetadata(TypedDict):
     long_description: str
     metric_type: MetricType
     needs_images: bool
-    score_normalization: bool
     short_description: str
     title: str
     threshold: float
@@ -175,15 +174,6 @@ class Metric(ABC):
         providing full details makes sense.
         """
         pass
-
-    @property
-    def SCORE_NORMALIZATION(self) -> bool:
-        """
-        If the score normalization will be applied to metrics from this metric as default in the app.
-        :return: True or False
-        """
-
-        return False
 
     @property
     def NEEDS_IMAGES(self):

--- a/src/encord_active/lib/metrics/semantic/_class_uncertainty.py
+++ b/src/encord_active/lib/metrics/semantic/_class_uncertainty.py
@@ -219,7 +219,6 @@ network and Monte-Carlo Dropout to estimate the uncertainty of the label. """
 
 class ConfidenceScoreMetric(Metric):
     TITLE = "Class Confidence Score"
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.SEMANTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = [AnnotationType.OBJECT.BOUNDING_BOX, AnnotationType.OBJECT.POLYGON]

--- a/src/encord_active/lib/metrics/semantic/_heatmap_uncertainty.py
+++ b/src/encord_active/lib/metrics/semantic/_heatmap_uncertainty.py
@@ -197,7 +197,6 @@ def train_model(model, model_path, batches):
 
 class EntropyHeatmapMetric(Metric):
     TITLE = "Heatmap uncertainty"
-    SCORE_NORMALIZATION = True
     METRIC_TYPE = MetricType.SEMANTIC
     DATA_TYPE = DataType.IMAGE
     ANNOTATION_TYPE = AnnotationType.ALL

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -86,11 +86,13 @@ def get_metric_operation_level(pth: Path) -> str:
     return "O" if object_hashes else "F"
 
 
-def is_valid_annotaion_type(annotaion_type: Union[None, List[str]], metric_scope: Optional[MetricScope] = None) -> bool:
+def is_valid_annotation_type(
+    annotation_type: Union[None, List[str]], metric_scope: Optional[MetricScope] = None
+) -> bool:
     if metric_scope == MetricScope.DATA_QUALITY:
-        return annotaion_type is None
+        return annotation_type is None
     elif metric_scope == MetricScope.LABEL_QUALITY:
-        return isinstance(annotaion_type, list)
+        return isinstance(annotation_type, list)
     else:
         return True
 
@@ -112,7 +114,7 @@ def load_available_metrics(metric_dir: Path, metric_scope: Optional[MetricScope]
         return out
 
     for p, n, m, l in zip(paths, names, meta_data, levels):
-        if m is None or not l or not is_valid_annotaion_type(m.get("annotation_type"), metric_scope):
+        if m is None or not l or not is_valid_annotation_type(m.get("annotation_type"), metric_scope):
 
             continue
 


### PR DESCRIPTION
Recent refactoring actions decoupled the `app` from `lib`, in this PR we remove `score_normalization` boolean attribute from the metric class as this behaviour is expected to be managed by the `app`.