### PR TITLE
feat (maskrcnn-example): make training log optional

### DIFF
--- a/examples/maskrcnn-example/example_config.ini
+++ b/examples/maskrcnn-example/example_config.ini
@@ -7,9 +7,11 @@ validation_ann = '/path/to/validation/annotation/file'
 
 [LOGGING]
 # calculating mAP takes too much time, so we calculate it in every nth step
+# calculating train set mAP is optional, disabling it will significantly increase training time
 wandb_enabled = True
 wandb_project = wandb_project_name
-performance_tracking_interval = 3
+log_train_map = False
+performance_tracking_interval = 2
 
 [TRAIN]
 # lr_scheduling patience and early_stopping_thresh are based on the performance_tracking_interval

--- a/examples/maskrcnn-example/generate_ea_predictions.py
+++ b/examples/maskrcnn-example/generate_ea_predictions.py
@@ -13,7 +13,6 @@ from utils.provider import get_config, get_transform
 from encord_active.lib.db.predictions import Format, Prediction
 
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-confidence_threshold = 0.5
 
 predictions_to_store = []
 
@@ -37,7 +36,7 @@ with torch.no_grad():
     for img, _, img_metadata in tqdm(dataset_validation, desc="Generating Encord Predictions"):
         prediction = model([img.to(device)])
 
-        scores_filter = prediction[0]["scores"] > confidence_threshold
+        scores_filter = prediction[0]["scores"] > params.inference.confidence_threshold
         masks = prediction[0]["masks"][scores_filter].detach().cpu().numpy()
         labels = prediction[0]["labels"][scores_filter].detach().cpu().numpy()
         scores = prediction[0]["scores"][scores_filter].detach().cpu().numpy()

--- a/examples/maskrcnn-example/train.py
+++ b/examples/maskrcnn-example/train.py
@@ -127,14 +127,17 @@ def main(params):
         train_one_epoch(model, device, data_loader, optimizer, log_freq=10)
 
         if epoch % params.logging.performance_tracking_interval == 0:
-            train_map = evaluate(model, device, data_loader, train_map_metric)
+            if params.logging.log_train_map:
+                train_map = evaluate(model, device, data_loader, train_map_metric)
             val_map = evaluate(model, device, data_loader_validation, val_map_metric)
 
             if params.train.use_lr_scheduler:
                 scheduler.step(val_map["map"])
 
             if params.logging.wandb_enabled:
-                train_map_logs = {f"train/{k}": v.item() for k, v in train_map.items()}
+                train_map_logs = {}
+                if params.logging.log_train_map:
+                    train_map_logs = {f"train/{k}": v.item() for k, v in train_map.items()}
                 val_map_logs = {f"val/{k}": v.item() for k, v in val_map.items()}
                 wandb.log(
                     {


### PR DESCRIPTION
mAP calculation takes too much time; therefore, it is optional for the training set now.