### PR TITLE
fix(iterator): link correct image paths to data units on image groups

### DIFF
--- a/src/encord_active/lib/common/iterator.py
+++ b/src/encord_active/lib/common/iterator.py
@@ -73,13 +73,11 @@ class DatasetIterator(Iterator):
             self.label_hash = label_hash
             if label_row.data_type in {"img_group", "image"}:
                 self.num_frames = len(label_row.data_units)
-                image_paths = self.project.image_paths[label_hash]
-
                 data_units = sorted(label_row.data_units.values(), key=lambda du: int(du["data_sequence"]))
-                for data_unit, image_path in zip(data_units, image_paths):
+                for data_unit in data_units:
                     self.du_hash = data_unit["data_hash"]
                     self.frame = int(data_unit["data_sequence"])
-                    yield data_unit, image_path
+                    yield data_unit, self.project.image_paths[label_hash][self.du_hash]
                     pbar.update(1)
             elif label_row.data_type == "video":
                 data_unit, *_ = label_row["data_units"].values()

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -36,7 +36,7 @@ class Project:
         self.ontology: OntologyStructure = OntologyStructure.from_dict(dict(objects=[], classifications=[]))
         self.label_row_meta: Dict[str, LabelRowMetadata] = {}
         self.label_rows: Dict[str, LabelRow] = {}
-        self.image_paths: Dict[str, List[Path]] = {}
+        self.image_paths: Dict[str, Dict[str, Path]] = {}
 
     def load(self, subset_size: Optional[int] = None) -> Project:
         """
@@ -156,7 +156,7 @@ class Project:
                 )
                 continue
             self.label_rows[lr_hash] = LabelRow(json.loads(lr_structure.label_row_file.read_text(encoding="utf-8")))
-            self.image_paths[lr_hash] = list(lr_structure.images_dir.iterdir())
+            self.image_paths[lr_hash] = dict((du_file.stem, du_file) for du_file in lr_structure.images_dir.iterdir())
 
 
 def get_label_row(


### PR DESCRIPTION
Image paths and data units are sorted in a different fashion so they can't be used in a per index fashion, but instead linked by their data unit hash.