### PR TITLE
fix(predictions): properly draw bounding box predictions

### DIFF
--- a/src/encord_active/lib/common/image_utils.py
+++ b/src/encord_active/lib/common/image_utils.py
@@ -43,22 +43,23 @@ def draw_object(
     hex_color = color.value if isinstance(color, Color) else color
     _color: Tuple[int, ...] = hex_to_rgb(hex_color)
     _color_outline: Tuple[int, ...] = hex_to_rgb(hex_color, lighten=-0.5)
-    if isinstance(row["rle"], str):
-        if with_box:
-            box = get_bbox_csv(row)
-            image = cv2.polylines(image, [box], isClosed, _color, thickness // 2, lineType=cv2.LINE_8)
 
-        mask = rle_to_binary_mask(eval(row["rle"]))
+    if with_box or not isinstance(row["rle"], str):
+        box = get_bbox_csv(row)
+        return cv2.polylines(image, [box], isClosed, _color, thickness, lineType=cv2.LINE_8)
 
-        # Draw contour line
-        contours = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
-        image = cv2.polylines(image, contours, isClosed, _color_outline, thickness, lineType=cv2.LINE_8)
+    mask = rle_to_binary_mask(eval(row["rle"]))
 
-        # Fill polygon with opacity
-        patch = np.zeros_like(image)
-        mask_select = mask == 1
-        patch[mask_select] = _color
-        image[mask_select] = cv2.addWeighted(image, (1 - mask_opacity), patch, mask_opacity, 0)[mask_select]
+    # Draw contour line
+    contours = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
+    image = cv2.polylines(image, contours, isClosed, _color_outline, thickness, lineType=cv2.LINE_8)
+
+    # Fill polygon with opacity
+    patch = np.zeros_like(image)
+    mask_select = mask == 1
+    patch[mask_select] = _color
+    image[mask_select] = cv2.addWeighted(image, (1 - mask_opacity), patch, mask_opacity, 0)[mask_select]
+
     return image
 
 

--- a/src/encord_active/lib/model_predictions/reader.py
+++ b/src/encord_active/lib/model_predictions/reader.py
@@ -38,7 +38,7 @@ class LabelSchema(IdentifierSchema):
     y1: Series[padt.Int64] = pa.Field(coerce=True)
     x2: Series[padt.Int64] = pa.Field(coerce=True)
     y2: Series[padt.Int64] = pa.Field(coerce=True)
-    rle: Series[object] = pa.Field()
+    rle: Series[object] = pa.Field(nullable=True, coerce=True)
 
 
 class PredictionSchema(LabelSchema):


### PR DESCRIPTION
Bounding box predictions doesn't work for two reasons:

1. The dataframe schemas that we defined for the predictions didn't allow empty RLEs. When a bounding box prediction is imported in the app, the rle will be NaN in the data frames because they don't have a mask. This is fixed.
2. The plotting of the predictions in the TP, FP, and FN pages were missing objects, as they expected an RLE. This is fixed.

We should introduce an object detection dataset to the sandbox datasets to be able to test these things regularly.