### PR TITLE
fix: broader exception handling range when reading images

### DIFF
--- a/examples/maskrcnn-example/utils/downscale_dataset.py
+++ b/examples/maskrcnn-example/utils/downscale_dataset.py
@@ -32,8 +32,12 @@ def resize_images(root_folder: Path, target_width: int, target_height: int):
             for item in data_units.glob("*.*"):
                 if item.as_posix().endswith((".png", ".jpg", ".jpeg", "tiff", ".tif", ".bmp", ".gif")):
                     target_file_path = target_data_path / "/".join(item.as_posix().split("/")[-3:])
-                    img = cv2.imread(item.as_posix())
-                    img_resized = cv2.resize(img, (target_width, target_height), interpolation=cv2.INTER_AREA)
+                    try:
+                        img = cv2.imread(item.as_posix())
+                        img_resized = cv2.resize(img, (target_width, target_height), interpolation=cv2.INTER_AREA)
+                    except Exception:
+                        print(f"Corrupted file: {item.as_posix}")
+                        continue
                     cv2.imwrite(target_file_path.as_posix(), img_resized)
                 else:
                     print(f"Not supported file: {item.as_posix()}")

--- a/src/encord_active/lib/coco/importer.py
+++ b/src/encord_active/lib/coco/importer.py
@@ -49,7 +49,10 @@ def upload_img(
             print(f"Image {coco_image.file_name} not found")
             return None
 
-    img = pil_image.open(file_path)
+    try:
+        img = pil_image.open(file_path)
+    except Exception:
+        return None
     img_exif = img.getexif()
     if img_exif and (274 in img_exif):  # 274 corresponds to orientation key for EXIF metadata
         temp_file_name = "temp_image" + file_path.suffix

--- a/src/encord_active/lib/common/image_utils.py
+++ b/src/encord_active/lib/common/image_utils.py
@@ -126,7 +126,7 @@ def load_or_fill_image(row: Union[pd.Series, str], data_dir: Path) -> np.ndarray
         try:
             image = cv2.imread(img_pth.as_posix())
             return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        except cv2.error:
+        except Exception:
             pass
 
     # Read not successful, so tell the user why

--- a/src/encord_active/lib/common/utils.py
+++ b/src/encord_active/lib/common/utils.py
@@ -102,7 +102,7 @@ def get_du_size(data_unit: dict, img_pth: Optional[Path] = None) -> Optional[Tup
         try:
             image = cv2.imread(img_pth.as_posix())
             return image.shape[:2]
-        except cv2.error:
+        except Exception:
             image_corrupted = True
 
     return None

--- a/src/encord_active/lib/embeddings/cnn.py
+++ b/src/encord_active/lib/embeddings/cnn.py
@@ -60,7 +60,10 @@ def assemble_object_batch(data_unit: dict, img_path: Path, transforms: Optional[
     if transforms is None:
         transforms = torch.nn.Sequential()
 
-    image = image_path_to_tensor(img_path)
+    try:
+        image = image_path_to_tensor(img_path)
+    except Exception:
+        return None
     img_batch: List[torch.Tensor] = []
 
     for obj in data_unit["labels"].get("objects", []):

--- a/src/encord_active/lib/metrics/heuristic/img_features.py
+++ b/src/encord_active/lib/metrics/heuristic/img_features.py
@@ -26,7 +26,7 @@ def iterate_with_rank_fn(
         try:
             image = cv2.imread(img_pth.as_posix())
             image = cv2.cvtColor(image, color_space)
-        except cv2.error:
+        except Exception:
             continue
         writer.write(rank_fn(image))
 

--- a/src/encord_active/lib/model_predictions/importers.py
+++ b/src/encord_active/lib/model_predictions/importers.py
@@ -148,7 +148,10 @@ def import_mask_predictions(
                     logger.warning(f"Couldn't match file {pth} to any data unit.")
                     continue
 
-                input_mask = np.array(Image.open(pth))
+                try:
+                    input_mask = np.array(Image.open(pth))
+                except Exception:
+                    continue
                 for cls in np.unique(input_mask):
                     if cls == 0:  # background
                         continue


### PR DESCRIPTION
Some corrupted images have not been captured by current checks so we broaden them in order to avoid app failure. Next iterations will add error log handling to detect these special cases and handle them accordingly.