### PR TITLE
fix(cli): target option more informative help text

### DIFF
--- a/src/encord_active/cli/imports.py
+++ b/src/encord_active/cli/imports.py
@@ -15,11 +15,7 @@ import_cli = typer.Typer(rich_markup_mode="markdown")
 @import_cli.command(name="predictions")
 @ensure_project
 def import_predictions(
-    predictions_path: Path = typer.Argument(
-        ...,
-        help="Path to a predictions file.",
-        dir_okay=False,
-    ),
+    predictions_path: Path = typer.Argument(..., help="Path to a predictions file.", dir_okay=False, exists=True),
     target: Path = typer.Option(Path.cwd(), "--target", "-t", help="Path to the target project.", file_okay=False),
     coco: bool = typer.Option(False, help="Import a coco result format file"),
 ):

--- a/src/encord_active/cli/utils/decorators.py
+++ b/src/encord_active/cli/utils/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 import rich
 import typer
@@ -20,17 +20,90 @@ def bypass_streamlit_question(fn: Callable[..., R]) -> Callable[..., R]:
     return inner
 
 
+def try_find_parent_project(target: Path) -> Optional[Path]:
+    for parent in target.parents:
+        if (parent / "project_meta.yaml").is_file():
+            return parent
+    return None
+
+
+def find_child_projects(target: Path) -> List[Path]:
+    child_meta_files = target.glob("*/project_meta.yaml")
+    return [cmf.parent.relative_to(target) for cmf in child_meta_files]
+
+
 def ensure_project(fn: Callable[..., R]) -> Callable[..., R]:
     @wraps(fn)
     def inner(*args: Any, **kwargs: Any) -> Any:
-        if not (kwargs["target"] / "project_meta.yaml").exists():
+        target: Optional[Path] = kwargs.get("target", None)
+        if target is None:
+            raise ValueError("Missing argument: `target`")
+
+        if (target / "project_meta.yaml").is_file():
+            return fn(*args, **kwargs)
+
+        from rich.panel import Panel
+
+        parent_target = try_find_parent_project(target)
+        if parent_target is not None:
             rich.print(
-                f"""
-[red]Couldn't find a project at:[/red] {kwargs['target']}
-[yellow]Make sure you either `cd` into directory containing a project or specify it with the `--target` option.[/yellow]
-                """
+                Panel(
+                    f"""
+The directory is a subdirectory of a project. 
+Executing command on parent directory
+[purple]{parent_target}[/purple]
+                    """,
+                    title=":file_folder: Found parent project :file_folder:",
+                    style="blue",
+                    expand=False,
+                )
             )
-            raise typer.Abort()
-        fn(*args, **kwargs)
+            kwargs["target"] = parent_target
+            return fn(*args, **kwargs)
+
+        child_projects = find_child_projects(target)
+        if child_projects:
+            from InquirerPy import inquirer as i
+            from InquirerPy.base.control import Choice
+
+            rich.print(
+                Panel(
+                    """
+The specified directory is not an Encord Project. 
+Encord Active found the following projects to choose from.
+                    """,
+                    title="🕵️  Select a project 🕵️",
+                    expand=False,
+                    style="blue",
+                )
+            )
+            choices = list(map(lambda p: Choice(p, name=p.name), child_projects))
+            choosen_target = i.fuzzy(
+                message="Choose a project",
+                choices=choices,
+                vi_mode=True,
+                instruction="Type a search string or use arrow keys and hit [enter]. Hit [ctrl-c] to abort.",
+            ).execute()
+            if choosen_target:
+                kwargs["target"] = choosen_target
+                return fn(*args, **kwargs)
+            rich.print("No project was selected. Aborting.")
+            raise typer.Exit()
+
+        rich.print(
+            Panel(
+                f"""
+Couldn't find a project at: [purple]{kwargs['target']}[/purple].
+Either [blue]`cd`[/blue] into a directory containing a project or specify the path with the `--target` option.
+
+:bulb: hint: By default, projects are stored in the current working directory when you run the [blue]init[/blue], [blue]import[/blue], and [blue]download[/blue] commands.
+            """,
+                title=":exclamation: Couldn't find a project :exclamation:",
+                style="yellow",
+                expand=False,
+            )
+        )
+
+        raise typer.Exit()
 
     return inner


### PR DESCRIPTION
Before, running commands that require a project directory would fail like this:
<img width="844" alt="image" src="https://user-images.githubusercontent.com/93145535/214534172-f5413dc8-7ac4-4558-af10-8aed1aabd047.png">

Now we do 3 things:

1. If one of the target's parents is a project directory, we use that
<img width="856" alt="image" src="https://user-images.githubusercontent.com/93145535/214535515-0dd38b57-c85e-4ed4-b340-e0bc32560c02.png">

2. If any of the immediate children of the target is a project directory, prompt the user to select which one to execute the command on
<img width="860" alt="image" src="https://user-images.githubusercontent.com/93145535/214535642-a81249ad-9de2-4322-9a3c-3ac1d5458672.png">

3. Otherwise, show help text
<img width="865" alt="image" src="https://user-images.githubusercontent.com/93145535/214535283-5e7a0a72-93d0-456e-8b07-c8ccde65950c.png">
