### PR TITLE
fix(cli): printing ontology looks for json instead of using sdk

### DIFF
--- a/src/encord_active/cli/print.py
+++ b/src/encord_active/cli/print.py
@@ -44,10 +44,26 @@ def print_ontology(
     """
     [bold]Prints[/bold] an ontology mapping between the class name to the `featureNodeHash` JSON format.
     """
-    from encord_active.lib.common.utils import get_local_project
+    from rich.panel import Panel
 
-    project = get_local_project(target)
-    objects = project.ontology["objects"]
+    from encord_active.lib.project.project_file_structure import ProjectFileStructure
+
+    fs = ProjectFileStructure(target)
+    if not fs.ontology.is_file():
+        rich.print(
+            Panel(
+                """
+Couldn't identify a project ontology. The reason for this may be that you have a very old project. Please try re-importing the project.
+                """,
+                title=":exclamation: :exclamation: ",
+                style="yellow",
+                expand=False,
+            )
+        )
+
+        raise typer.Exit()
+
+    objects = json.loads(fs.ontology.read_text())["objects"]
 
     ontology = {o["name"].lower(): o["featureNodeHash"] for o in objects}
     json_ontology = json.dumps(ontology, indent=2)

--- a/src/encord_active/lib/common/utils.py
+++ b/src/encord_active/lib/common/utils.py
@@ -54,17 +54,6 @@ class ProjectNotFound(Exception):
         super().__init__(f"Couldn't find meta file for project in `{project_dir}`")
 
 
-def get_local_project(project_dir: Path) -> Project:
-    project_meta = fetch_project_meta(project_dir)
-
-    ssh_key_path = Path(project_meta["ssh_key_path"])
-    with open(ssh_key_path.expanduser(), "r", encoding="utf-8") as f:
-        key = f.read()
-
-    client = EncordUserClient.create_with_ssh_private_key(key)
-    return client.get_project(project_meta.get("project_hash"))
-
-
 def fetch_project_meta(data_dir: Path) -> ProjectMeta:
     meta_file = data_dir / "project_meta.yaml"
     if not meta_file.is_file():


### PR DESCRIPTION
Print ontology was broken for locally imported projects. Now the command looks for the locally available `ontology.json` file instead of querying the SDK.