### PR TITLE
Feat(cli): add non-interactive use of metricize

### DIFF
--- a/src/encord_active/cli/main.py
+++ b/src/encord_active/cli/main.py
@@ -269,12 +269,13 @@ def metricize(
     target: Path = typer.Option(
         Path.cwd(), "--target", "-t", help="Directory of the project to run the metrics on.", file_okay=False
     ),
-    metric_names: Optional[list[str]] = typer.Option(
-        None,
+    metric_names: list[str] = typer.Option(
+        [],
         "--add",
         "-a",
         help="Name of the metric to run. This option can be repeated to add multiple metrics to the run.",
     ),
+    run_all: bool = typer.Option(False, "--all", help="Run all available metrics."),
     fuzzy: bool = typer.Option(
         False, help="Enable fuzzy search in the selection. (press [TAB] to select more than one) 🪄"
     ),
@@ -292,9 +293,11 @@ def metricize(
     )
 
     metrics = list(map(load_metric, get_metrics()))
+    if run_all:  # User chooses to run all available metrics
+        selected_metrics = metrics
 
     # (interactive) User chooses some metrics via CLI prompt selection
-    if metric_names is None:
+    elif not metric_names:
         choices = list(map(lambda m: Choice(m, name=m.TITLE), metrics))
         Options = TypedDict("Options", {"message": str, "choices": List[Choice], "vi_mode": bool})
         options: Options = {

--- a/src/encord_active/cli/main.py
+++ b/src/encord_active/cli/main.py
@@ -266,14 +266,9 @@ def quickstart(
 @cli.command()
 @ensure_project
 def metricize(
+    metric_names: Optional[list[str]] = typer.Argument(None, help="Names of the metrics to run."),
     target: Path = typer.Option(
         Path.cwd(), "--target", "-t", help="Directory of the project to run the metrics on.", file_okay=False
-    ),
-    metric_names: list[str] = typer.Option(
-        [],
-        "--add",
-        "-a",
-        help="Name of the metric to run. This option can be repeated to add multiple metrics to the run.",
     ),
     run_all: bool = typer.Option(False, "--all", help="Run all available metrics."),
     fuzzy: bool = typer.Option(

--- a/src/encord_active/cli/main.py
+++ b/src/encord_active/cli/main.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Set, TypedDict
+from typing import List, Optional, Set, TypedDict
 
 import click
 import rich
@@ -269,6 +269,12 @@ def metricize(
     target: Path = typer.Option(
         Path.cwd(), "--target", "-t", help="Directory of the project to run the metrics on.", file_okay=False
     ),
+    metric_names: Optional[list[str]] = typer.Option(
+        None,
+        "--add",
+        "-a",
+        help="Name of the metric to run. This option can be repeated to add multiple metrics to the run.",
+    ),
     fuzzy: bool = typer.Option(
         False, help="Enable fuzzy search in the selection. (press [TAB] to select more than one) 🪄"
     ),
@@ -286,19 +292,45 @@ def metricize(
     )
 
     metrics = list(map(load_metric, get_metrics()))
-    choices = list(map(lambda m: Choice(m, name=m.TITLE), metrics))
-    Options = TypedDict("Options", {"message": str, "choices": List[Choice], "vi_mode": bool})
-    options: Options = {
-        "message": "What metrics would you like to run?",
-        "choices": choices,
-        "vi_mode": True,
-    }
 
-    if fuzzy:
-        options["message"] += " [blue](press [TAB] to select more than one)[/blue]"
-        selected_metrics = i.fuzzy(**options, multiselect=True).execute()
+    # (interactive) User chooses some metrics via CLI prompt selection
+    if metric_names is None:
+        choices = list(map(lambda m: Choice(m, name=m.TITLE), metrics))
+        Options = TypedDict("Options", {"message": str, "choices": List[Choice], "vi_mode": bool})
+        options: Options = {
+            "message": "What metrics would you like to run?",
+            "choices": choices,
+            "vi_mode": True,
+        }
+
+        if fuzzy:
+            options["message"] += " [blue](press [TAB] to select more than one)[/blue]"
+            selected_metrics = i.fuzzy(**options, multiselect=True).execute()
+        else:
+            selected_metrics = i.checkbox(**options).execute()
+
+    # (non-interactive) User chooses some metrics via --add (-a) option
     else:
-        selected_metrics = i.checkbox(**options).execute()
+        metric_name_to_cls = {m.TITLE: m for m in metrics}
+        used_metric_names = set()
+        selected_metrics = []
+        unknown_metric_names = []
+        for name in metric_names:
+            if name in used_metric_names:  # repeated metric name in --add
+                continue
+            used_metric_names.add(name)
+
+            metric_cls = metric_name_to_cls.get(name, None)
+            if metric_cls is None:  # unknown and/or wrong metric name in user selection
+                unknown_metric_names.append(name)
+            else:
+                selected_metrics.append(metric_cls)
+
+        if len(unknown_metric_names) > 0:
+            rich.print("No available metric has this name:")
+            for name in unknown_metric_names:
+                rich.print(f"[yellow]{name}[/yellow]")
+            raise typer.Abort()
 
     execute_metrics(selected_metrics, data_dir=target, use_cache_only=True)
 

--- a/src/encord_active/cli/main.py
+++ b/src/encord_active/cli/main.py
@@ -270,7 +270,7 @@ def metricize(
         Path.cwd(), "--target", "-t", help="Directory of the project to run the metrics on.", file_okay=False
     ),
     fuzzy: bool = typer.Option(
-        False, help="Enbale fuzzy search in the selection. (press [TAB] to select more than one) 🪄"
+        False, help="Enable fuzzy search in the selection. (press [TAB] to select more than one) 🪄"
     ),
 ):
     """


### PR DESCRIPTION
Now, users can add metric names to `metricize` command with the optional input `--add` (`-a`) in case they already know the name of the metrics they want to execute. This implementation allows the user to run the `metricize` command in a non-interactive fashion keeping it simple for the user to rerun the same metrics.