### PR TITLE
docs: correct image path to link to actual file

### DIFF
--- a/docs/docs/cli/download-sandbox-data.md
+++ b/docs/docs/cli/download-sandbox-data.md
@@ -78,7 +78,7 @@ Sample pictures:
 - **Read More:** [Webpage](https://www.cosmiqworks.org/rareplanes/)
 
 Sample pictures:
-![Rareplanes dataset](../images/rareplanes.png)
+![Rareplanes dataset](../images/Rareplanes.png)
 
 ## TACO Dataset
 


### PR DESCRIPTION
An image path directed to `rareplanes.png` instead of actual file `Rareplanes.png`. Fixed.