### PR TITLE
[FIX] replace is used instead of rename

### DIFF
--- a/src/encord_active/app/common/components/metric_summary.py
+++ b/src/encord_active/app/common/components/metric_summary.py
@@ -64,12 +64,12 @@ def render_2d_metric_plots(metrics_data_summary: MetricsSeverity):
         x_metric_df = metrics_data_summary.metrics[str(x_metric_name)].df[
             [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
         ]
-        x_metric_df.rename(columns={MetricWithDistanceSchema.score: f"{CrossMetricSchema.x}"}, inplace=True)
+        x_metric_df.columns = x_metric_df.columns.str.replace(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.x}')
 
         y_metric_df = metrics_data_summary.metrics[str(y_metric_name)].df[
             [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
         ]
-        y_metric_df.rename(columns={MetricWithDistanceSchema.score: f"{CrossMetricSchema.y}"}, inplace=True)
+        y_metric_df.columns = y_metric_df.columns.str.replace(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.y}')
 
         if x_metric_df.shape[0] == 0:
             st.info(f'Score file of metric "{x_metric_name}" is empty, please run this metric again.')

--- a/src/encord_active/app/common/components/metric_summary.py
+++ b/src/encord_active/app/common/components/metric_summary.py
@@ -62,14 +62,14 @@ def render_2d_metric_plots(metrics_data_summary: MetricsSeverity):
         )
 
         x_metric_df = metrics_data_summary.metrics[str(x_metric_name)].df[
-            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
+            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score].copy()
         ]
-        x_metric_df.columns = x_metric_df.columns.str.replace(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.x}')
+        x_metric_df.columns.str.rename(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.x}', inplace=True)
 
         y_metric_df = metrics_data_summary.metrics[str(y_metric_name)].df[
-            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
+            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score].copy()
         ]
-        y_metric_df.columns = y_metric_df.columns.str.replace(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.y}')
+        y_metric_df.columns.str.rename(f'{MetricWithDistanceSchema.score}', f'{CrossMetricSchema.y}', inplace=True)
 
         if x_metric_df.shape[0] == 0:
             st.info(f'Score file of metric "{x_metric_name}" is empty, please run this metric again.')


### PR DESCRIPTION
This fix is because recent pandas update throws warnings while running the app, pandas requests replace to be used instead of rename in their documentation.