### PR TITLE
fix: avoids renaming a dataframe view

### DIFF
--- a/src/encord_active/app/common/components/metric_summary.py
+++ b/src/encord_active/app/common/components/metric_summary.py
@@ -61,14 +61,18 @@ def render_2d_metric_plots(metrics_data_summary: MetricsSeverity):
             help="Draws a trend line to demonstrate the relationship between the two metrics.",
         )
 
-        x_metric_df = metrics_data_summary.metrics[str(x_metric_name)].df[
-            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
-        ]
+        x_metric_df = (
+            metrics_data_summary.metrics[str(x_metric_name)]
+            .df[[MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]]
+            .copy()
+        )
         x_metric_df.rename(columns={MetricWithDistanceSchema.score: f"{CrossMetricSchema.x}"}, inplace=True)
 
-        y_metric_df = metrics_data_summary.metrics[str(y_metric_name)].df[
-            [MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]
-        ]
+        y_metric_df = (
+            metrics_data_summary.metrics[str(y_metric_name)]
+            .df[[MetricWithDistanceSchema.identifier, MetricWithDistanceSchema.score]]
+            .copy()
+        )
         y_metric_df.rename(columns={MetricWithDistanceSchema.score: f"{CrossMetricSchema.y}"}, inplace=True)
 
         if x_metric_df.shape[0] == 0:


### PR DESCRIPTION
Based on the discussions [here](https://github.com/encord-team/encord-active/pull/156)