### PR TITLE
Feat (mAP plots): change to plotly graphs for interactivity

### DIFF
--- a/src/encord_active/app/model_quality/sub_pages/metrics.py
+++ b/src/encord_active/app/model_quality/sub_pages/metrics.py
@@ -3,7 +3,7 @@ from pandera.typing import DataFrame
 
 from encord_active.app.common.state import get_state
 from encord_active.lib.charts.metric_importance import create_metric_importance_charts
-from encord_active.lib.charts.precision_recall import create_pr_charts
+from encord_active.lib.charts.precision_recall import create_pr_chart_plotly
 from encord_active.lib.model_predictions.map_mar import (
     PerformanceMetricSchema,
     PrecisionRecallSchema,
@@ -103,5 +103,6 @@ class MetricsPage(ModelQualityPage):
 
         st.subheader("Subset selection scores")
         with st.container():
-            chart = create_pr_charts(metrics, precisions)
-            st.altair_chart(chart, use_container_width=True)
+
+            chart = create_pr_chart_plotly(metrics, precisions, get_state().project_paths.ontology)
+            st.plotly_chart(chart, use_container_width=True)

--- a/src/encord_active/app/model_quality/sub_pages/metrics.py
+++ b/src/encord_active/app/model_quality/sub_pages/metrics.py
@@ -1,3 +1,5 @@
+import json
+
 import streamlit as st
 from pandera.typing import DataFrame
 
@@ -103,6 +105,6 @@ class MetricsPage(ModelQualityPage):
 
         st.subheader("Subset selection scores")
         with st.container():
-
-            chart = create_pr_chart_plotly(metrics, precisions, get_state().project_paths.ontology)
+            project_ontology = json.loads(get_state().project_paths.ontology.read_text(encoding="utf-8"))
+            chart = create_pr_chart_plotly(metrics, precisions, project_ontology["objects"])
             st.plotly_chart(chart, use_container_width=True)

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -1,5 +1,10 @@
+import json
+from pathlib import Path
+
 import altair as alt
+import plotly.graph_objects as go
 from pandera.typing import DataFrame
+from plotly.subplots import make_subplots
 
 from encord_active.lib.model_predictions.map_mar import (
     PerformanceMetricSchema,
@@ -82,3 +87,80 @@ def create_pr_charts(metrics: DataFrame[PerformanceMetricSchema], precisions: Da
     )
     precision_chart = (class_precisions + mean_precisions).add_selection(class_selection)
     return bar_chart | precision_chart
+
+
+def create_pr_chart_plotly(
+    metrics: DataFrame[PerformanceMetricSchema], precisions: DataFrame[PrecisionRecallSchema], ontology_path: Path
+):
+    _metrics: DataFrame[PerformanceMetricSchema] = metrics[~metrics[_M_COLS.metric].isin({"mAR", "mAP"})].copy()
+
+    tmp = "m" + _metrics["metric"].str.split("_", n=1, expand=True)
+    tmp.columns = ["group", "_"]
+    _metrics["group"] = tmp["group"]
+    _metrics["average"] = "average"  # Legend title
+
+    _metrics.sort_values(by=["group", _M_COLS.value], ascending=[False, True], inplace=True)
+
+    fig = make_subplots(rows=1, cols=2, subplot_titles=("AP and AR", "Precision-Recall Curve"))
+
+    project_ontology = json.loads(ontology_path.read_text(encoding="utf-8"))
+
+    colors = {}
+    for object in project_ontology["objects"]:
+        colors[object["name"]] = object["color"]
+
+    for class_name in _metrics[PerformanceMetricSchema.class_name].unique():
+        fig.add_trace(
+            go.Bar(
+                x=_metrics.loc[_metrics[PerformanceMetricSchema.class_name] == class_name][_M_COLS.value],
+                y=_metrics.loc[_metrics[PerformanceMetricSchema.class_name] == class_name][_M_COLS.metric],
+                orientation="h",
+                name=class_name,
+                legendgroup=class_name,
+                marker={"color": colors[class_name]},
+            ),
+            row=1,
+            col=1,
+        )
+
+    # Average
+    fig.add_trace(
+        go.Bar(
+            x=[
+                _metrics.loc[_metrics["group"] == "mAP"][_M_COLS.value].mean(),
+                _metrics.loc[_metrics["group"] == "mAR"][_M_COLS.value].mean(),
+            ],
+            y=["AP_average", "AR_average"],
+            orientation="h",
+            name="Average",
+            legendgroup="Average",
+        ),
+        row=1,
+        col=1,
+    )
+
+    for class_name in precisions[PrecisionRecallSchema.class_name].unique():
+        fig.add_trace(
+            go.Scatter(
+                x=precisions.loc[precisions[PrecisionRecallSchema.class_name] == class_name][
+                    PrecisionRecallSchema.recall
+                ],
+                y=precisions.loc[precisions[PrecisionRecallSchema.class_name] == class_name][
+                    PrecisionRecallSchema.precision
+                ],
+                mode="lines+markers",
+                name=class_name,
+                legendgroup=class_name,
+                showlegend=False,
+                marker={"color": colors[class_name]},
+            ),
+            row=1,
+            col=2,
+        )
+
+    fig["layout"]["xaxis"]["title"] = "Score"
+    fig["layout"]["xaxis2"]["title"] = "Recall"
+    fig["layout"]["yaxis"]["title"] = "Class"
+    fig["layout"]["yaxis2"]["title"] = "Precision"
+
+    return fig

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import altair as alt
 import plotly.graph_objects as go
 from pandera.typing import DataFrame
 from plotly.subplots import make_subplots

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -15,7 +15,9 @@ _M_COLS = PerformanceMetricSchema
 
 
 def create_pr_chart_plotly(
-    metrics: DataFrame[PerformanceMetricSchema], precisions: DataFrame[PrecisionRecallSchema], ontology_path: Path
+    metrics: DataFrame[PerformanceMetricSchema],
+    precisions: DataFrame[PrecisionRecallSchema],
+    annotation_colors: list[dict],
 ):
     _metrics: DataFrame[PerformanceMetricSchema] = metrics[~metrics[_M_COLS.metric].isin({"mAR", "mAP"})].copy()
 
@@ -26,12 +28,12 @@ def create_pr_chart_plotly(
 
     _metrics.sort_values(by=["group", _M_COLS.value], ascending=[False, True], inplace=True)
 
-    fig = make_subplots(rows=1, cols=2, subplot_titles=("Per class Average Precision and Recall", "Precision-Recall Curve"))
-
-    project_ontology = json.loads(ontology_path.read_text(encoding="utf-8"))
+    fig = make_subplots(
+        rows=1, cols=2, subplot_titles=("Per class Average Precision and Recall", "Precision-Recall Curve")
+    )
 
     colors = {}
-    for obj in project_ontology["objects"]:
+    for obj in annotation_colors:
         colors[obj["name"]] = obj["color"]
 
     for class_name in _metrics[PerformanceMetricSchema.class_name].unique():

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -26,7 +26,7 @@ def create_pr_chart_plotly(
 
     _metrics.sort_values(by=["group", _M_COLS.value], ascending=[False, True], inplace=True)
 
-    fig = make_subplots(rows=1, cols=2, subplot_titles=("AP and AR", "Precision-Recall Curve"))
+    fig = make_subplots(rows=1, cols=2, subplot_titles=("Per class Average Precision and Recall", "Precision-Recall Curve"))
 
     project_ontology = json.loads(ontology_path.read_text(encoding="utf-8"))
 

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -15,80 +15,6 @@ _PR_COLS = PrecisionRecallSchema
 _M_COLS = PerformanceMetricSchema
 
 
-def create_pr_charts(metrics: DataFrame[PerformanceMetricSchema], precisions: DataFrame[PrecisionRecallSchema]):
-    _metrics: DataFrame[PerformanceMetricSchema] = metrics[~metrics[_M_COLS.metric].isin({"mAR", "mAP"})].copy()
-
-    tmp = "m" + _metrics["metric"].str.split("_", n=1, expand=True)
-    tmp.columns = ["group", "_"]
-    _metrics["group"] = tmp["group"]
-    _metrics["average"] = "average"  # Legend title
-
-    class_selection = alt.selection_multi(fields=[_M_COLS.class_name])
-
-    _metrics.sort_values(by=["group", _M_COLS.value], ascending=[True, False], inplace=True)
-
-    class_bars = (
-        alt.Chart(_metrics, title="Mean scores")
-        .mark_bar()
-        .encode(
-            alt.X(_M_COLS.value, title="", scale=alt.Scale(domain=[0.0, 1.0])),
-            alt.Y(_M_COLS.metric, title="", sort=None),
-            alt.Color(_M_COLS.class_name),
-            tooltip=[
-                alt.Tooltip(_M_COLS.metric, title="Metric"),
-                alt.Tooltip(_M_COLS.value, title="Value", format=",.3f"),
-            ],
-            opacity=alt.condition(class_selection, alt.value(1), alt.value(0.1)),
-        )
-        .properties(height=300)
-    )
-    # Average
-    mean_bars = class_bars.encode(
-        alt.X(f"mean({_M_COLS.value}):Q", title="", scale=alt.Scale(domain=[0.0, 1.0])),
-        alt.Y("group:N", title="", sort=None),
-        alt.Color("average:N"),
-        tooltip=[
-            alt.Tooltip("group:N", title="Metric"),
-            alt.Tooltip(f"mean({_M_COLS.value}):Q", title="Value", format=",.3f"),
-        ],
-    )
-    bar_chart = (class_bars + mean_bars).add_selection(class_selection)
-
-    class_precisions = (
-        alt.Chart(precisions, title="Precision-Recall Curve")
-        .mark_line(point=True)
-        .encode(
-            alt.X(_PR_COLS.recall, title="Recall", scale=alt.Scale(domain=[0.0, 1.0])),
-            alt.Y(_PR_COLS.precision, scale=alt.Scale(domain=[0.0, 1.0])),
-            alt.Color(_PR_COLS.class_name),
-            tooltip=[
-                alt.Tooltip(_PR_COLS.class_name),
-                alt.Tooltip(_PR_COLS.recall, title="Recall"),
-                alt.Tooltip(_PR_COLS.precision, title="Precision", format=",.3f"),
-            ],
-            opacity=alt.condition(class_selection, alt.value(1.0), alt.value(0.2)),
-        )
-        .properties(height=300)
-    )
-
-    mean_precisions = (
-        class_precisions.transform_calculate(average="'average'")
-        .mark_line(point=True)
-        .encode(
-            alt.X(_PR_COLS.recall),
-            alt.Y(f"average({_PR_COLS.precision}):Q"),
-            alt.Color("average:N"),
-            tooltip=[
-                alt.Tooltip("average:N", title="Aggregate"),
-                alt.Tooltip(_PR_COLS.recall, title="Recall"),
-                alt.Tooltip(f"average({_PR_COLS.precision})", title="Avg. precision", format=",.3f"),
-            ],
-        )
-    )
-    precision_chart = (class_precisions + mean_precisions).add_selection(class_selection)
-    return bar_chart | precision_chart
-
-
 def create_pr_chart_plotly(
     metrics: DataFrame[PerformanceMetricSchema], precisions: DataFrame[PrecisionRecallSchema], ontology_path: Path
 ):
@@ -106,8 +32,8 @@ def create_pr_chart_plotly(
     project_ontology = json.loads(ontology_path.read_text(encoding="utf-8"))
 
     colors = {}
-    for object in project_ontology["objects"]:
-        colors[object["name"]] = object["color"]
+    for obj in project_ontology["objects"]:
+        colors[obj["name"]] = obj["color"]
 
     for class_name in _metrics[PerformanceMetricSchema.class_name].unique():
         fig.add_trace(

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -53,10 +53,10 @@ def create_pr_chart_plotly(
     fig.add_trace(
         go.Bar(
             x=[
-                _metrics.loc[_metrics["group"] == "mAP"][_M_COLS.value].mean(),
                 _metrics.loc[_metrics["group"] == "mAR"][_M_COLS.value].mean(),
+                _metrics.loc[_metrics["group"] == "mAP"][_M_COLS.value].mean(),
             ],
-            y=["AP_average", "AR_average"],
+            y=["AR_average", "AP_average"],
             orientation="h",
             name="Average",
             legendgroup="Average",

--- a/src/encord_active/lib/charts/precision_recall.py
+++ b/src/encord_active/lib/charts/precision_recall.py
@@ -1,6 +1,3 @@
-import json
-from pathlib import Path
-
 import plotly.graph_objects as go
 from pandera.typing import DataFrame
 from plotly.subplots import make_subplots


### PR DESCRIPTION
There were no zooming property in altair chart and in the presence of many classes, texts were overlapping onto each other.
There are several things I am not sure on this PR:

- ontology path is sent to `create_pr_chart_plotly` function to get the original colors (and assign same colors to both subplots). Is sending the path correct way to do that?
- In order to synchronize two subplots (AP-AR for classes and Precision-Recall curve), I had to use for loop to iterate over different classes. Which does not seem to me ideal but I could not find another way to do that in plotly.