### PR TITLE
Feat (explorer view): Simplify UI

### DIFF
--- a/docs/docs/metrics/write-your-own.md
+++ b/docs/docs/metrics/write-your-own.md
@@ -47,6 +47,7 @@ to the awesome paper that proposed the method.
 Or use math to better explain such method:
 $$h_{\lambda}(x) = \frac{1}{x^\intercal x}$$
 """,
+            doc_url='link/to/documentation', # This is optional, if a link is given, it can be accessed from the app
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[AnnotationType.OBJECT.BOUNDING_BOX, AnnotationType.OBJECT.ROTATABLE_BOUNDING_BOX, AnnotationType.OBJECT.POLYGON],

--- a/src/encord_active/app/data_quality/sub_pages/explorer.py
+++ b/src/encord_active/app/data_quality/sub_pages/explorer.py
@@ -117,9 +117,7 @@ class ExplorerPage(Page):
         if not selected_metric:
             return
 
-        # st.markdown(f"# {self.title}")
         st.markdown(f"### [{selected_metric.meta.title}]({selected_metric.meta.doc_url})")
-        # st.markdown(selected_metric.meta.long_description)
 
         if selected_df.empty:
             return

--- a/src/encord_active/app/data_quality/sub_pages/explorer.py
+++ b/src/encord_active/app/data_quality/sub_pages/explorer.py
@@ -117,7 +117,10 @@ class ExplorerPage(Page):
         if not selected_metric:
             return
 
-        st.markdown(f"### [{selected_metric.meta.title}]({selected_metric.meta.doc_url})")
+        if selected_metric.meta.doc_url == "":
+            st.markdown(f"### {selected_metric.meta.title}")
+        else:
+            st.markdown(f"### [{selected_metric.meta.title}]({selected_metric.meta.doc_url})")
 
         if selected_df.empty:
             return

--- a/src/encord_active/app/data_quality/sub_pages/explorer.py
+++ b/src/encord_active/app/data_quality/sub_pages/explorer.py
@@ -117,9 +117,9 @@ class ExplorerPage(Page):
         if not selected_metric:
             return
 
-        st.markdown(f"# {self.title}")
-        st.markdown(f"## {selected_metric.meta.title}")
-        st.markdown(selected_metric.meta.long_description)
+        # st.markdown(f"# {self.title}")
+        st.markdown(f"### [{selected_metric.meta.title}]({selected_metric.meta.doc_url})")
+        # st.markdown(selected_metric.meta.long_description)
 
         if selected_df.empty:
             return

--- a/src/encord_active/app/data_quality/sub_pages/explorer.py
+++ b/src/encord_active/app/data_quality/sub_pages/explorer.py
@@ -117,7 +117,7 @@ class ExplorerPage(Page):
         if not selected_metric:
             return
 
-        if selected_metric.meta.doc_url == "":
+        if selected_metric.meta.doc_url is None:
             st.markdown(f"### {selected_metric.meta.title}")
         else:
             st.markdown(f"### [{selected_metric.meta.title}]({selected_metric.meta.doc_url})")

--- a/src/encord_active/lib/metrics/example.py
+++ b/src/encord_active/lib/metrics/example.py
@@ -26,6 +26,7 @@ to the awesome paper that proposed the method.
 Or use math to better explain such method:
 $$h_{\lambda}(x) = \frac{1}{x^\intercal x}$$
 """,
+            doc_url="link/to/documentation",  # This is optional, if a link is given, it can be accessed from the app
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/annotation_duplicates.py
+++ b/src/encord_active/lib/metrics/geometric/annotation_duplicates.py
@@ -23,6 +23,7 @@ class AnnotationDuplicates(Metric):
             long_description=r"""Ranks annotations by how likely they are to represent the same object.
 > [Jaccard similarity coefficient](https://en.wikipedia.org/wiki/Jaccard_index)
 is used to measure closeness of two annotations.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#annotation-duplicates",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/hu_static.py
+++ b/src/encord_active/lib/metrics/geometric/hu_static.py
@@ -40,6 +40,7 @@ class HuMomentsStatic(Metric):
             long_description=r"""Computes the Euclidean distance between the polygons'
     [Hu moments](https://en.wikipedia.org/wiki/Image_moment) for each class and
     the prototypical class moments.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#shape-outlier-detection",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[AnnotationType.OBJECT.POLYGON],

--- a/src/encord_active/lib/metrics/geometric/hu_temporal.py
+++ b/src/encord_active/lib/metrics/geometric/hu_temporal.py
@@ -53,6 +53,7 @@ class HuMomentsTemporalMetric(Metric):
             long_description=r"""Ranks objects by how similar they are to their instances in previous frames
 based on [Hu moments](https://en.wikipedia.org/wiki/Image_moment). The more an object's shape changes,
 the lower its score will be.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[AnnotationType.OBJECT.POLYGON],

--- a/src/encord_active/lib/metrics/geometric/image_border_closeness.py
+++ b/src/encord_active/lib/metrics/geometric/image_border_closeness.py
@@ -19,6 +19,7 @@ class ImageBorderCloseness(Metric):
             title="Annotation closeness to image borders",
             short_description="Ranks annotations by how close they are to image borders.",
             long_description=r"""This metric ranks annotations by how close they are to image borders.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/object_size.py
+++ b/src/encord_active/lib/metrics/geometric/object_size.py
@@ -35,6 +35,7 @@ class RelativeObjectAreaMetric(Metric):
             title="Object Area - Relative",
             short_description="Computes object area as a percentage of total image area.",
             long_description=r"""Computes object area as a percentage of total image area.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -68,6 +69,7 @@ class OccupiedTotalAreaMetric(Metric):
             title="Frame object density",
             short_description="Computes the percentage of image area that's occupied by objects.",
             long_description=r"""Computes the percentage of image area that's occupied by objects.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -111,6 +113,7 @@ class AbsoluteObjectAreaMetric(Metric):
             title="Object Area - Absolute",
             short_description="Computes object area in amount of pixels",
             long_description=r"""Computes object area in amount of pixels.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#object-area---absolute",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -151,6 +154,7 @@ class ObjectAspectRatioMetric(Metric):
             title="Object Aspect Ratio",
             short_description="Computes aspect ratios of objects",
             long_description=r"""Computes aspect ratios ($width/height$) of objects.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#object-aspect-ratio",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
+++ b/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
@@ -28,6 +28,7 @@ class OcclusionDetectionOnVideo(Metric):
             short_description="Tracks objects and detect outliers",
             long_description=r"""This metric collects information related to object size and aspect ratio for each track
  and find outliers among them.""",
+            doc_url="https://encord-active-docs.web.app/metrics/geometric#detect-occlusion-in-video",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[AnnotationType.OBJECT.BOUNDING_BOX, AnnotationType.OBJECT.ROTATABLE_BOUNDING_BOX],

--- a/src/encord_active/lib/metrics/heuristic/high_iou_changing_classes.py
+++ b/src/encord_active/lib/metrics/heuristic/high_iou_changing_classes.py
@@ -54,6 +54,7 @@ track-ids, they will be flagged as potential inconsistencies in tracks.
 `Cat:2` will be flagged as potentially having a broken track, because track ids `1` and `2` doesn't match.
 
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#inconsistent-object-classification-and-track-ids",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/heuristic/img_features.py
+++ b/src/encord_active/lib/metrics/heuristic/img_features.py
@@ -24,6 +24,7 @@ class ContrastMetric(SimpleMetric):
 
 Contrast is computed as the standard deviation of the pixel values.
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#contrast",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -49,6 +50,7 @@ class Wrapper:  # we can't have a non-default-constructible Metric implementatio
                 short_description=f"Ranks images by how {color_name.lower()} the average value of the image is.",
                 long_description=f"""Ranks images by how {color_name.lower()} the average value of the
                     image is.""",
+                doc_url=f"https://encord-active-docs.web.app/metrics/heuristic/#{color_name.lower()}-values",
                 metric_type=MetricType.HEURISTIC,
                 data_type=DataType.IMAGE,
                 annotation_type=AnnotationType.NONE,
@@ -138,6 +140,7 @@ class BrightnessMetric(SimpleMetric):
 
 Brightness is computed as the average (normalized) pixel value across each image.
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#brightness",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -163,6 +166,7 @@ image.
 score = cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#sharpness",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -188,6 +192,7 @@ image. Note that this is $1 - \text{sharpness}$.
 score = 1 - cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#blur",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -207,6 +212,7 @@ class AspectRatioMetric(Metric):
 
 Aspect ratio is computed as the ratio of image width to image height ($\frac{width}{height}$).
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#aspect-ratio",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -231,6 +237,7 @@ class AreaMetric(Metric):
 
 Area is computed as the product of image width and image height ($width \times height$).
     """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#area",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,

--- a/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
+++ b/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
@@ -80,6 +80,7 @@ hash, they will be flagged as a potentially broken track.
 ```
 `CAT:2` will be marked as potentially having a wrong track id.
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#missing-objects-and-broken-tracks",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/heuristic/object_counting.py
+++ b/src/encord_active/lib/metrics/heuristic/object_counting.py
@@ -14,6 +14,7 @@ class ObjectsCountMetric(Metric):
             title="Object Count",
             short_description="Counts number of objects in the image",
             long_description=r"""Counts number of objects in the image.""",
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#object-count",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.ALL,

--- a/src/encord_active/lib/metrics/heuristic/random.py
+++ b/src/encord_active/lib/metrics/heuristic/random.py
@@ -16,6 +16,7 @@ class RandomeImageMetric(Metric):
             title="Random Values on Images",
             short_description="Assigns a random value between 0 and 1 to images",
             long_description="Uses a uniform distribution to generate a value between 0 and 1 to each image",
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#random-values-on-images",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[],
@@ -34,6 +35,7 @@ class RandomeObjectMetric(Metric):
             title="Random Values on Objects",
             short_description="Assigns a random value between 0 and 1 to objects",
             long_description="Uses a uniform distribution to generate a value between 0 and 1 to each object",
+            doc_url="https://encord-active-docs.web.app/metrics/heuristic#random-values-on-objects",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/metric.py
+++ b/src/encord_active/lib/metrics/metric.py
@@ -61,6 +61,7 @@ class MetricMetadata(BaseModel):
     title: str
     short_description: str
     long_description: str
+    doc_url: str
     metric_type: MetricType
     data_type: DataType
     annotation_type: List[AnnotationTypeUnion]
@@ -82,6 +83,7 @@ class SimpleMetric(ABC):
         data_type: DataType,
         annotation_type: List[Union[ObjectShape, ClassificationType]],
         embedding_type: Optional[EmbeddingType] = None,
+        doc_url: str = "",
     ):
         self.metadata = MetricMetadata(
             title=title,
@@ -91,6 +93,7 @@ class SimpleMetric(ABC):
             data_type=data_type,
             annotation_type=annotation_type,
             embedding_type=embedding_type,
+            doc_url=doc_url,
             stats=StatsMetadata(),
         )
 
@@ -109,6 +112,7 @@ class Metric(ABC):
         data_type: DataType,
         annotation_type: List[Union[ObjectShape, ClassificationType]] = [],
         embedding_type: Optional[EmbeddingType] = None,
+        doc_url: str = "",
     ):
         self.metadata = MetricMetadata(
             title=title,
@@ -118,6 +122,7 @@ class Metric(ABC):
             data_type=data_type,
             annotation_type=annotation_type,
             embedding_type=embedding_type,
+            doc_url=doc_url,
             stats=StatsMetadata(),
         )
 

--- a/src/encord_active/lib/metrics/metric.py
+++ b/src/encord_active/lib/metrics/metric.py
@@ -61,11 +61,11 @@ class MetricMetadata(BaseModel):
     title: str
     short_description: str
     long_description: str
-    doc_url: str
     metric_type: MetricType
     data_type: DataType
     annotation_type: List[AnnotationTypeUnion]
     embedding_type: Optional[EmbeddingType] = None
+    doc_url: Optional[str] = None
     stats: StatsMetadata
 
     def get_unique_name(self):
@@ -83,7 +83,7 @@ class SimpleMetric(ABC):
         data_type: DataType,
         annotation_type: List[Union[ObjectShape, ClassificationType]],
         embedding_type: Optional[EmbeddingType] = None,
-        doc_url: str = "",
+        doc_url: Optional[str] = None,
     ):
         self.metadata = MetricMetadata(
             title=title,
@@ -112,7 +112,7 @@ class Metric(ABC):
         data_type: DataType,
         annotation_type: List[Union[ObjectShape, ClassificationType]] = [],
         embedding_type: Optional[EmbeddingType] = None,
-        doc_url: str = "",
+        doc_url: Optional[str] = None,
     ):
         self.metadata = MetricMetadata(
             title=title,

--- a/src/encord_active/lib/metrics/semantic/image_singularity.py
+++ b/src/encord_active/lib/metrics/semantic/image_singularity.py
@@ -37,6 +37,7 @@ This metric gives each image a score that shows each image's uniqueness.
 - **To delete duplicate images:** You can set the quality filter to cover only zero values (that ends up with all the duplicate images), then use bulk tagging (e.g., with a tag like `Duplicate`) to tag all images.
 - **To mark duplicate images:** Near duplicate images are shown side by side. Navigate through these images and mark whichever is of interest to you.
 """,
+            doc_url="https://encord-active-docs.web.app/metrics/semantic#image-singularity",
             metric_type=MetricType.SEMANTIC,
             data_type=DataType.IMAGE,
             embedding_type=EmbeddingType.CLASSIFICATION,

--- a/src/encord_active/lib/metrics/semantic/img_classification_quality.py
+++ b/src/encord_active/lib/metrics/semantic/img_classification_quality.py
@@ -57,6 +57,7 @@ class ImageLevelQualityTest(Metric):
             long_description=r"""This metric creates embeddings from images. Then, these embeddings are used to build
     nearest neighbor graph. Similar embeddings' classifications are compared against each other.
         """,
+            doc_url="https://encord-active-docs.web.app/metrics/semantic#image-level-annotation-quality",
             metric_type=MetricType.SEMANTIC,
             data_type=DataType.IMAGE,
             annotation_type=[AnnotationType.CLASSIFICATION.RADIO],

--- a/src/encord_active/lib/metrics/semantic/img_object_quality.py
+++ b/src/encord_active/lib/metrics/semantic/img_object_quality.py
@@ -43,6 +43,7 @@ class ObjectEmbeddingSimilarityTest(Metric):
     and an embedding for each bounding box is extracted. Then, these embeddings are compared
     with their neighbors. If the neighbors are annotated differently, a low score is given to it.
     """,
+            doc_url="https://encord-active-docs.web.app/metrics/semantic#object-annotation-quality",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -130,7 +130,7 @@ def load_metric_metadata(meta_pth) -> MetricMetadata:
             metric_type=old_meta.get("metric_type", old_meta.get("index_type")),
             embedding_type=old_meta.get("embedding_type", None),
             annotation_type=annotation_type,
-            doc_url=old_meta.get("doc_url", ""),
+            doc_url=old_meta.get("doc_url", "https://encord-active-docs.web.app/category/metrics"),
             stats=stats,
         )
         with meta_pth.open("w") as f:

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -130,6 +130,7 @@ def load_metric_metadata(meta_pth) -> MetricMetadata:
             metric_type=old_meta.get("metric_type", old_meta.get("index_type")),
             embedding_type=old_meta.get("embedding_type", None),
             annotation_type=annotation_type,
+            doc_url=old_meta.get("doc_url", ""),
             stats=stats,
         )
         with meta_pth.open("w") as f:

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -130,7 +130,7 @@ def load_metric_metadata(meta_pth) -> MetricMetadata:
             metric_type=old_meta.get("metric_type", old_meta.get("index_type")),
             embedding_type=old_meta.get("embedding_type", None),
             annotation_type=annotation_type,
-            doc_url=old_meta.get("doc_url", "https://encord-active-docs.web.app/category/metrics"),
+            doc_url=old_meta.get("doc_url", ""),
             stats=stats,
         )
         with meta_pth.open("w") as f:

--- a/src/encord_active/lib/metrics/utils.py
+++ b/src/encord_active/lib/metrics/utils.py
@@ -130,7 +130,7 @@ def load_metric_metadata(meta_pth) -> MetricMetadata:
             metric_type=old_meta.get("metric_type", old_meta.get("index_type")),
             embedding_type=old_meta.get("embedding_type", None),
             annotation_type=annotation_type,
-            doc_url=old_meta.get("doc_url", ""),
+            doc_url=old_meta.get("doc_url", None),
             stats=stats,
         )
         with meta_pth.open("w") as f:


### PR DESCRIPTION
As discussed in the last week's [meeting](https://www.notion.so/Design-planning-3-3-2023-07b3ada603724eeaaa4049df920f6014), explorer view is simplified by removing unnecessary text. A new attribute called `doc_url` is added to metrics that points to their documentation page. By clicking on the metric name, users can directly go to the related documentation page if it is provided (it goes to the main documentation page if this attribute does not exist in meta file, to not create a breaking change for the existing projects, sandbox etc.).
