### PR TITLE
fix: create metrics directory if not exists

### DIFF
--- a/src/encord_active/lib/metrics/metadata.py
+++ b/src/encord_active/lib/metrics/metadata.py
@@ -13,4 +13,5 @@ def fetch_metrics_meta(project_dir: Path):
 
 def update_metrics_meta(project_dir: Path, updated_meta: dict):
     meta_file_path = project_dir / "metrics" / "metrics_meta.json"
+    meta_file_path.parent.mkdir(exist_ok=True)
     meta_file_path.write_text(json.dumps(updated_meta, indent=2), encoding="utf-8")


### PR DESCRIPTION
The inti function was broken due to the new metric meta data structure introduced in #199 