### PR TITLE
docs: redirect links to the official encord docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 If you're using Encord Active in your organization, please try to add your company name to the [ADOPTERS.md](./ADOPTERS.md). It really helps the project to gain momentum and credibility. It's a small contribution back to the project with a big impact.
 
-Read the [contributing docs](https://encord-active-docs.web.app/contributing).
+Read the [contributing docs](https://docs.encord.com/active/docs/contributing).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://encord-active-docs.web.app" target="_blank">Documentation</a> |
+<a href="https://docs.encord.com/active/docs" target="_blank">Documentation</a> |
 <a href="https://colab.research.google.com/drive/11iZE1CCFIGlkWdTmhf5XACDojtGeIRGS?usp=sharing" target="_blank">Try it Now</a> |
 <a href="https://encord.com/encord_active/" target="_blank">Website</a> |
 <a href="https://encord.com/blog/" target="_blank">Blog</a> |
@@ -39,12 +39,12 @@ Whether you've just started collecting data, labeled your first batch of samples
 
 ## 🔖 Documentation
 
-Our full documentation is available [here](https://encord-active-docs.web.app). In particular we recommend checking out:
+Our full documentation is available [here](https://docs.encord.com/active/docs). In particular we recommend checking out:
 
-- [Getting Started](https://encord-active-docs.web.app/)
+- [Getting Started](https://docs.encord.com/active/docs/getting-started)
 - [Workflows][encord-active-docs-workflow]
-- [Tutorials](https://encord-active-docs.web.app/category/tutorials)
-- [CLI Documentation](https://encord-active-docs.web.app/category/command-line-interface)
+- [Tutorials](https://docs.encord.com/active/docs/category/tutorials)
+- [CLI Documentation](https://docs.encord.com/active/docs/category/command-line-interface)
 
 ## Installation
 
@@ -158,16 +158,16 @@ Encord Active ships with 25+ metrics and more are coming; [contributions][contri
 
 ### Core features:
 
-- [Data Exploration](https://encord-active-docs.web.app/pages/data-quality/summary)
-- [Data Outlier detection](https://encord-active-docs.web.app/workflows/Improve-your-data/identify-outliers-edge-cases)
-- [Label Outlier detection](https://encord-active-docs.web.app/workflows/improve-your-labels/identify-outliers)
-- [Model Decomposition](https://encord-active-docs.web.app/pages/model-quality/metrics)
-- [Similarity Search](https://encord-active-docs.web.app/workflows/Improve-your-data/similar-images)
-- [Annotator Benchmarks](https://encord-active-docs.web.app/pages/label-quality/explorer/)
-- [Data Tagging](https://encord-active-docs.web.app/workflows/tags/#steps)
-- [Visualise TP/FP/FN](https://encord-active-docs.web.app/category/model-quality)
-- [Dataset Balancing](https://encord-active-docs.web.app/pages/export/balance_export)
-- [COCO Exports](https://encord-active-docs.web.app/pages/export/filter_export)
+- [Data Exploration](https://docs.encord.com/active/docs/pages/data-quality/summary)
+- [Data Outlier detection](https://docs.encord.com/active/docs/workflows/improve-your-data/identify-outliers-edge-cases)
+- [Label Outlier detection](https://docs.encord.com/active/docs/workflows/improve-your-labels/identify-outliers)
+- [Model Decomposition](https://docs.encord.com/active/docs/pages/model-quality/metrics)
+- [Similarity Search](https://docs.encord.com/active/docs/workflows/improve-your-data/similar-images)
+- [Annotator Benchmarks](https://docs.encord.com/active/docs/pages/label-quality/explorer/)
+- [Data Tagging](https://docs.encord.com/active/docs/workflows/tags/#steps)
+- [Visualise TP/FP/FN](https://docs.encord.com/active/docs/category/model-quality)
+- [Dataset Balancing](https://docs.encord.com/active/docs/pages/export/balance_export)
+- [COCO Exports](https://docs.encord.com/active/docs/pages/export/filter_export)
 - And much more!
 
 Visit our [documentation][encord-active-docs] to learn more.
@@ -214,12 +214,12 @@ This repository is published under the Apache 2.0 licence.
 
 [adopters]: https://github.com/encord-team/encord-active/blob/main/ADOPTERS.md
 [colab-notebook]: https://colab.research.google.com/drive/11iZE1CCFIGlkWdTmhf5XACDojtGeIRGS?usp=sharing
-[contribute-url]: https://encord-active-docs.web.app/contributing
-[encord-active-docs-init]: https://encord-active-docs.web.app/cli/initialising-project-from-image-directories
-[encord-active-docs-workflow-import-data]: https://encord-active-docs.web.app/workflows/import-data
-[encord-active-docs-workflow]: https://encord-active-docs.web.app/category/workflows
+[contribute-url]: https://docs.encord.com/active/docs/contributing
+[encord-active-docs-init]: https://docs.encord.com/active/docs/cli/initialising-project-from-image-directories
+[encord-active-docs-workflow-import-data]: https://docs.encord.com/active/docs/workflows/import-data
+[encord-active-docs-workflow]: https://docs.encord.com/active/docs/category/workflows
 [encord-active-docs-write-metric]: https://docs.encord.com/active/docs/metrics/write-your-own
-[encord-active-docs]: https://encord-active-docs.web.app/
+[encord-active-docs]: https://docs.encord.com/active/docs
 [encord-active-landing]: https://encord.com/encord-active/
 [encord-docs-ssh]: https://docs.encord.com/admins/settings/public-keys/#set-up-public-key-authentication
 [join-slack]: https://join.slack.com/t/encordactive/shared_invite/zt-1hc2vqur9-Fzj1EEAHoqu91sZ0CX0A7Q

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ This repository is published under the Apache 2.0 licence.
 [encord-active-docs-init]: https://encord-active-docs.web.app/cli/initialising-project-from-image-directories
 [encord-active-docs-workflow-import-data]: https://encord-active-docs.web.app/workflows/import-data
 [encord-active-docs-workflow]: https://encord-active-docs.web.app/category/workflows
-[encord-active-docs-write-metric]: https://encord-active-docs.web.app/metrics/write-your-own
+[encord-active-docs-write-metric]: https://docs.encord.com/active/docs/metrics/write-your-own
 [encord-active-docs]: https://encord-active-docs.web.app/
 [encord-active-landing]: https://encord.com/encord-active/
 [encord-docs-ssh]: https://docs.encord.com/admins/settings/public-keys/#set-up-public-key-authentication

--- a/examples/README.md
+++ b/examples/README.md
@@ -118,10 +118,10 @@ If you want to share your notebooks, custom metrics, or improve the tool, please
 [colab-image]: https://colab.research.google.com/assets/colab-badge.svg
 [colab-notebook]: https://colab.research.google.com/drive/11iZE1CCFIGlkWdTmhf5XACDojtGeIRGS?usp=sharing
 [contribute-image]: https://img.shields.io/badge/PRs-welcome-blue.svg
-[contribute-url]: https://encord-active-docs.web.app/contributing
+[contribute-url]: https://docs.encord.com/active/docs/contributing
 [docs-image]: https://img.shields.io/badge/docs-online-blue
 [encord-active-docs-write-metric]: https://docs.encord.com/active/docs/metrics/write-your-own
-[encord-active-docs]: https://encord-active-docs.web.app/
+[encord-active-docs]: https://docs.encord.com/active/docs
 [join-slack]: https://join.slack.com/t/encordactive/shared_invite/zt-1hc2vqur9-Fzj1EEAHoqu91sZ0CX0A7Q
 [license-image]: https://img.shields.io/github/license/encord-team/encord-active
 [pypi-package-image]: https://img.shields.io/pypi/v/encord-active

--- a/examples/README.md
+++ b/examples/README.md
@@ -120,7 +120,7 @@ If you want to share your notebooks, custom metrics, or improve the tool, please
 [contribute-image]: https://img.shields.io/badge/PRs-welcome-blue.svg
 [contribute-url]: https://encord-active-docs.web.app/contributing
 [docs-image]: https://img.shields.io/badge/docs-online-blue
-[encord-active-docs-write-metric]: https://encord-active-docs.web.app/metrics/write-your-own
+[encord-active-docs-write-metric]: https://docs.encord.com/active/docs/metrics/write-your-own
 [encord-active-docs]: https://encord-active-docs.web.app/
 [join-slack]: https://join.slack.com/t/encordactive/shared_invite/zt-1hc2vqur9-Fzj1EEAHoqu91sZ0CX0A7Q
 [license-image]: https://img.shields.io/github/license/encord-team/encord-active

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://encord-active-docs.web.app" target="_blank">Documentation</a> |
+<a href="https://docs.encord.com/active/docs" target="_blank">Documentation</a> |
 <a href="https://colab.research.google.com/drive/11iZE1CCFIGlkWdTmhf5XACDojtGeIRGS?usp=sharing" target="_blank">Try it Now</a> |
 <a href="https://encord.com/encord_active/" target="_blank">Website</a> |
 <a href="https://encord.com/blog/" target="_blank">Blog</a> |
@@ -21,7 +21,7 @@
 
 In this directory, you find examples of how to use Encord Active.
 
-Generally, you need to have installed [`encord-active`](https://encord-active-docs.web.app) and [`jupyter-lab`](#jupyter-lab).
+Generally, you need to have installed [`encord-active`](https://docs.encord.com/active/docs) and [`jupyter-lab`](#jupyter-lab).
 
 ## Table of Contensts
 

--- a/examples/building-a-custom-metric-function.ipynb
+++ b/examples/building-a-custom-metric-function.ipynb
@@ -72,8 +72,8 @@
     "\n",
     "Other points that we want to highlight is that \n",
     "\n",
-    "1. Encord Active ships with a bunch of [pre-defined metrics](https://encord-active-docs.web.app/category/metrics) that will automatically be run on your data when you import it.\n",
-    "2. When you've [imported your model predictions](https://encord-active-docs.web.app/workflows/import-predictions), Encord Active will _automatically_ identify those metrics that are more important for your model performance.\n",
+    "1. Encord Active ships with a bunch of [pre-defined metrics](https://docs.encord.com/active/docs/category/metrics) that will automatically be run on your data when you import it.\n",
+    "2. When you've [imported your model predictions](https://docs.encord.com/active/docs/workflows/import-predictions), Encord Active will _automatically_ identify those metrics that are more important for your model performance.\n",
     "\n",
     "This tutorial will take you through how to write such metric functions and use them with Encord Active."
    ]

--- a/examples/download-sandbox-dataset.ipynb
+++ b/examples/download-sandbox-dataset.ipynb
@@ -9,7 +9,7 @@
     "# Download a sandbox dataset\n",
     "\n",
     "**Prerequisites:**\n",
-    "You need to have encord-active [installed](https://encord-active-docs.web.app/installation).\n",
+    "You need to have encord-active [installed](https://docs.encord.com/active/docs/installation).\n",
     "\n",
     "This notebook shows you how to download a sandbox dataset through code.\n",
     "It follows three steps.\n",

--- a/examples/getting-started-with-coco-project.ipynb
+++ b/examples/getting-started-with-coco-project.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook shows you how to import a locally stored COCO project into Encord Active.\n",
     "\n",
-    "**Prerequisites:** you should have `encord-active[coco]` [installed](https://encord-active-docs.web.app/installation#coco-extras) and you should have a project available in a COCO format."
+    "**Prerequisites:** you should have `encord-active[coco]` [installed](https://docs.encord.com/active/docs/installation#coco-extras) and you should have a project available in a COCO format."
    ]
   },
   {

--- a/examples/getting-started-with-coco-project.ipynb
+++ b/examples/getting-started-with-coco-project.ipynb
@@ -89,9 +89,9 @@
     "\n",
     "You may want to import your model predictions as well.\n",
     "\n",
-    "For that, you can follow [this part](https://encord-active-docs.web.app/workflows/import-predictions) of the documentation.\n",
+    "For that, you can follow [this part](https://docs.encord.com/active/docs/workflows/import-predictions) of the documentation.\n",
     "\n",
-    "[The docs](https://encord-active-docs.web.app/category/workflows) also describes workflows for, e.g., finding outliers in your data."
+    "[The docs](https://docs.encord.com/active/docs/category/workflows) also describes workflows for, e.g., finding outliers in your data."
    ]
   }
  ],

--- a/examples/getting-started-with-encord-projects.ipynb
+++ b/examples/getting-started-with-encord-projects.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook shows you how to import existing Encord projects into Encord Active.\n",
     "\n",
-    "**Prerequisites:** you should have `encord-active` [installed](https://encord-active-docs.web.app/installation) and you should have an Encord account.\n",
+    "**Prerequisites:** you should have `encord-active` [installed](https://docs.encord.com/active/docs/installation) and you should have an Encord account.\n",
     "\n",
     "> If you don't have an Encord project already, you might want to have a look at the [Getting Started with a COCO project](./getting-started-with-coco.ipynb) notebook instead.\n",
     "\n",

--- a/examples/getting-started-with-encord-projects.ipynb
+++ b/examples/getting-started-with-encord-projects.ipynb
@@ -178,9 +178,9 @@
     "\n",
     "You may want to import your model predictions as well.\n",
     "\n",
-    "For that, you can follow [this part](https://encord-active-docs.web.app/workflows/import-predictions) of the documentation.\n",
+    "For that, you can follow [this part](https://docs.encord.com/active/docs/workflows/import-predictions) of the documentation.\n",
     "\n",
-    "[The docs](https://encord-active-docs.web.app/category/workflows) also describes workflows for, e.g., finding outliers in your data."
+    "[The docs](https://docs.encord.com/active/docs/category/workflows) also describes workflows for, e.g., finding outliers in your data."
    ]
   }
  ],

--- a/examples/maskrcnn-example/workflows/improve_dataset_by_fixing_labels.md
+++ b/examples/maskrcnn-example/workflows/improve_dataset_by_fixing_labels.md
@@ -6,7 +6,7 @@ On Encord-Annotate, open the project, go to Settings => Copy project. Select eve
 
 2. Import the new project to Encord-Active.
 
-See documentation: https://encord-active-docs.web.app/cli/import-encord-project 
+See documentation: https://docs.encord.com/active/docs/cli/import-encord-project
 
 3. Open the Encord-Active app.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers=[
     "Topic :: Software Development",
     "Topic :: Software Development :: Quality Assurance"
 ]
-documentation = "https://encord-active-docs.web.app/"
+documentation = "https://docs.encord.com/active/docs"
 homepage = "https://encord.com/encord-active/"
 keywords = ["encord", "active", "machine", "learning", "data", "label", "model", "quality", "test"]
 readme = "README.md"

--- a/src/encord_active/lib/coco/__init__.py
+++ b/src/encord_active/lib/coco/__init__.py
@@ -5,6 +5,6 @@ except ModuleNotFoundError:
     raise SystemExit(
         """
         Some dependencies were not found. Please ensure to install encord-active[coco] when using the COCO parsers/importerself.
-        Addional information can be found here: https://encord-active-docs.web.app/installation#coco-extras
+        Addional information can be found here: https://docs.encord.com/active/docs/installation#coco-extras
         """
     )

--- a/src/encord_active/lib/constants.py
+++ b/src/encord_active/lib/constants.py
@@ -1,4 +1,4 @@
-DOCS_URL = "https://encord-active-docs.web.app"
+DOCS_URL = "https://docs.encord.com/active/docs"
 GITHUB_URL = "https://github.com/encord-team/encord-active"
 SLACK_INVITE_URL = "https://join.slack.com/t/encordactive/shared_invite/zt-1hc2vqur9-Fzj1EEAHoqu91sZ0CX0A7Q"
 SLACK_URL = "https://encordactive.slack.com"

--- a/src/encord_active/lib/metrics/geometric/annotation_duplicates.py
+++ b/src/encord_active/lib/metrics/geometric/annotation_duplicates.py
@@ -23,7 +23,7 @@ class AnnotationDuplicates(Metric):
             long_description=r"""Ranks annotations by how likely they are to represent the same object.
 > [Jaccard similarity coefficient](https://en.wikipedia.org/wiki/Jaccard_index)
 is used to measure closeness of two annotations.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#annotation-duplicates",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#annotation-duplicates",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/hu_static.py
+++ b/src/encord_active/lib/metrics/geometric/hu_static.py
@@ -40,7 +40,7 @@ class HuMomentsStatic(Metric):
             long_description=r"""Computes the Euclidean distance between the polygons'
     [Hu moments](https://en.wikipedia.org/wiki/Image_moment) for each class and
     the prototypical class moments.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#shape-outlier-detection",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#shape-outlier-detection",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[AnnotationType.OBJECT.POLYGON],

--- a/src/encord_active/lib/metrics/geometric/hu_temporal.py
+++ b/src/encord_active/lib/metrics/geometric/hu_temporal.py
@@ -53,7 +53,7 @@ class HuMomentsTemporalMetric(Metric):
             long_description=r"""Ranks objects by how similar they are to their instances in previous frames
 based on [Hu moments](https://en.wikipedia.org/wiki/Image_moment). The more an object's shape changes,
 the lower its score will be.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[AnnotationType.OBJECT.POLYGON],

--- a/src/encord_active/lib/metrics/geometric/image_border_closeness.py
+++ b/src/encord_active/lib/metrics/geometric/image_border_closeness.py
@@ -19,7 +19,7 @@ class ImageBorderCloseness(Metric):
             title="Annotation closeness to image borders",
             short_description="Ranks annotations by how close they are to image borders.",
             long_description=r"""This metric ranks annotations by how close they are to image borders.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/object_size.py
+++ b/src/encord_active/lib/metrics/geometric/object_size.py
@@ -35,7 +35,7 @@ class RelativeObjectAreaMetric(Metric):
             title="Object Area - Relative",
             short_description="Computes object area as a percentage of total image area.",
             long_description=r"""Computes object area as a percentage of total image area.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -69,7 +69,7 @@ class OccupiedTotalAreaMetric(Metric):
             title="Frame object density",
             short_description="Computes the percentage of image area that's occupied by objects.",
             long_description=r"""Computes the percentage of image area that's occupied by objects.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#polygon-shape-similarity",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#polygon-shape-similarity",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -113,7 +113,7 @@ class AbsoluteObjectAreaMetric(Metric):
             title="Object Area - Absolute",
             short_description="Computes object area in amount of pixels",
             long_description=r"""Computes object area in amount of pixels.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#object-area---absolute",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#object-area---absolute",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[
@@ -154,7 +154,7 @@ class ObjectAspectRatioMetric(Metric):
             title="Object Aspect Ratio",
             short_description="Computes aspect ratios of objects",
             long_description=r"""Computes aspect ratios ($width/height$) of objects.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#object-aspect-ratio",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#object-aspect-ratio",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
+++ b/src/encord_active/lib/metrics/geometric/occlusion_detection_video.py
@@ -28,7 +28,7 @@ class OcclusionDetectionOnVideo(Metric):
             short_description="Tracks objects and detect outliers",
             long_description=r"""This metric collects information related to object size and aspect ratio for each track
  and find outliers among them.""",
-            doc_url="https://encord-active-docs.web.app/metrics/geometric#detect-occlusion-in-video",
+            doc_url="https://docs.encord.com/active/docs/metrics/geometric#detect-occlusion-in-video",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[AnnotationType.OBJECT.BOUNDING_BOX, AnnotationType.OBJECT.ROTATABLE_BOUNDING_BOX],

--- a/src/encord_active/lib/metrics/heuristic/high_iou_changing_classes.py
+++ b/src/encord_active/lib/metrics/heuristic/high_iou_changing_classes.py
@@ -54,7 +54,7 @@ track-ids, they will be flagged as potential inconsistencies in tracks.
 `Cat:2` will be flagged as potentially having a broken track, because track ids `1` and `2` doesn't match.
 
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#inconsistent-object-classification-and-track-ids",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#inconsistent-object-classification-and-track-ids",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/heuristic/img_features.py
+++ b/src/encord_active/lib/metrics/heuristic/img_features.py
@@ -24,7 +24,7 @@ class ContrastMetric(SimpleMetric):
 
 Contrast is computed as the standard deviation of the pixel values.
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#contrast",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#contrast",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -50,7 +50,7 @@ class Wrapper:  # we can't have a non-default-constructible Metric implementatio
                 short_description=f"Ranks images by how {color_name.lower()} the average value of the image is.",
                 long_description=f"""Ranks images by how {color_name.lower()} the average value of the
                     image is.""",
-                doc_url=f"https://encord-active-docs.web.app/metrics/heuristic/#{color_name.lower()}-values",
+                doc_url=f"https://docs.encord.com/active/docs/metrics/heuristic/#{color_name.lower()}-values",
                 metric_type=MetricType.HEURISTIC,
                 data_type=DataType.IMAGE,
                 annotation_type=AnnotationType.NONE,
@@ -140,7 +140,7 @@ class BrightnessMetric(SimpleMetric):
 
 Brightness is computed as the average (normalized) pixel value across each image.
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#brightness",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#brightness",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -166,7 +166,7 @@ image.
 score = cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#sharpness",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#sharpness",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -192,7 +192,7 @@ image. Note that this is $1 - \text{sharpness}$.
 score = 1 - cv2.Laplacian(image, cv2.CV_64F).var()
 ```
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#blur",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#blur",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -212,7 +212,7 @@ class AspectRatioMetric(Metric):
 
 Aspect ratio is computed as the ratio of image width to image height ($\frac{width}{height}$).
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#aspect-ratio",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#aspect-ratio",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,
@@ -237,7 +237,7 @@ class AreaMetric(Metric):
 
 Area is computed as the product of image width and image height ($width \times height$).
     """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#area",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#area",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.NONE,

--- a/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
+++ b/src/encord_active/lib/metrics/heuristic/missing_objects_and_wrong_tracks.py
@@ -80,7 +80,7 @@ hash, they will be flagged as a potentially broken track.
 ```
 `CAT:2` will be marked as potentially having a wrong track id.
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#missing-objects-and-broken-tracks",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#missing-objects-and-broken-tracks",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.SEQUENCE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/heuristic/object_counting.py
+++ b/src/encord_active/lib/metrics/heuristic/object_counting.py
@@ -14,7 +14,7 @@ class ObjectsCountMetric(Metric):
             title="Object Count",
             short_description="Counts number of objects in the image",
             long_description=r"""Counts number of objects in the image.""",
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#object-count",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#object-count",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=AnnotationType.ALL,

--- a/src/encord_active/lib/metrics/heuristic/random.py
+++ b/src/encord_active/lib/metrics/heuristic/random.py
@@ -16,7 +16,7 @@ class RandomeImageMetric(Metric):
             title="Random Values on Images",
             short_description="Assigns a random value between 0 and 1 to images",
             long_description="Uses a uniform distribution to generate a value between 0 and 1 to each image",
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#random-values-on-images",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#random-values-on-images",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[],
@@ -35,7 +35,7 @@ class RandomeObjectMetric(Metric):
             title="Random Values on Objects",
             short_description="Assigns a random value between 0 and 1 to objects",
             long_description="Uses a uniform distribution to generate a value between 0 and 1 to each object",
-            doc_url="https://encord-active-docs.web.app/metrics/heuristic#random-values-on-objects",
+            doc_url="https://docs.encord.com/active/docs/metrics/heuristic#random-values-on-objects",
             metric_type=MetricType.HEURISTIC,
             data_type=DataType.IMAGE,
             annotation_type=[

--- a/src/encord_active/lib/metrics/semantic/image_singularity.py
+++ b/src/encord_active/lib/metrics/semantic/image_singularity.py
@@ -37,7 +37,7 @@ This metric gives each image a score that shows each image's uniqueness.
 - **To delete duplicate images:** You can set the quality filter to cover only zero values (that ends up with all the duplicate images), then use bulk tagging (e.g., with a tag like `Duplicate`) to tag all images.
 - **To mark duplicate images:** Near duplicate images are shown side by side. Navigate through these images and mark whichever is of interest to you.
 """,
-            doc_url="https://encord-active-docs.web.app/metrics/semantic#image-singularity",
+            doc_url="https://docs.encord.com/active/docs/metrics/semantic#image-singularity",
             metric_type=MetricType.SEMANTIC,
             data_type=DataType.IMAGE,
             embedding_type=EmbeddingType.CLASSIFICATION,

--- a/src/encord_active/lib/metrics/semantic/img_classification_quality.py
+++ b/src/encord_active/lib/metrics/semantic/img_classification_quality.py
@@ -57,7 +57,7 @@ class ImageLevelQualityTest(Metric):
             long_description=r"""This metric creates embeddings from images. Then, these embeddings are used to build
     nearest neighbor graph. Similar embeddings' classifications are compared against each other.
         """,
-            doc_url="https://encord-active-docs.web.app/metrics/semantic#image-level-annotation-quality",
+            doc_url="https://docs.encord.com/active/docs/metrics/semantic#image-level-annotation-quality",
             metric_type=MetricType.SEMANTIC,
             data_type=DataType.IMAGE,
             annotation_type=[AnnotationType.CLASSIFICATION.RADIO],

--- a/src/encord_active/lib/metrics/semantic/img_object_quality.py
+++ b/src/encord_active/lib/metrics/semantic/img_object_quality.py
@@ -43,7 +43,7 @@ class ObjectEmbeddingSimilarityTest(Metric):
     and an embedding for each bounding box is extracted. Then, these embeddings are compared
     with their neighbors. If the neighbors are annotated differently, a low score is given to it.
     """,
-            doc_url="https://encord-active-docs.web.app/metrics/semantic#object-annotation-quality",
+            doc_url="https://docs.encord.com/active/docs/metrics/semantic#object-annotation-quality",
             metric_type=MetricType.GEOMETRIC,
             data_type=DataType.IMAGE,
             annotation_type=[


### PR DESCRIPTION
Redirected all `https://encord-active-docs.web.app/` links in the codebase to the official Encord docs `https://docs.encord.com/active/docs`.