### PR TITLE
fix: numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ encord-active = "encord_active.cli.main:cli"
 [tool.poetry.dependencies]
 python = ">=3.9,<3.9.7 || >3.9.7,<3.11"
 encord = "^0.1.67"
-numpy = "^1.23.5"
+numpy = ">=1.23.5,<1.24.0"
 opencv-python = "4.5.5.64"
 streamlit = "^1.19.0"
 natsort = "^8.1.0"


### PR DESCRIPTION
As discussed [here](https://github.com/numba/numba/issues/8615) latest numpy and numba versions are incompatible in windows OS.