### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/docs/active-learning/index.mdx
+++ b/docs/docs/active-learning/index.mdx
@@ -9,7 +9,7 @@ This is the idea behind active learning.
 
 **Encord Active** provides you with the tools to take advantage of the active learning method, and it's integrated with **Encord Annotate** to deliver the best annotation experience.
 
-If you are already familiar with the active learning foundation, continue your read with an exploration of [Encord Active's acquisition functions](/metrics/model-quality-metrics/#acquisition-functions) and our end-to-end tutorial about [easy active learning on MNIST](/tutorials/easy-active-learning-on-mnist).
+If you are already familiar with the active learning foundation, continue your read with an exploration of [Encord Active's acquisition functions](../metrics/model-quality-metrics/#acquisition-functions) and our end-to-end tutorial about [easy active learning on MNIST](../tutorials/easy-active-learning-on-mnist).
 
 ## What is active learning?
 

--- a/docs/docs/workflows/identify-outliers-edge-cases.md
+++ b/docs/docs/workflows/identify-outliers-edge-cases.md
@@ -11,7 +11,7 @@ Encord Active finds outliers using precomputed Interquartile ranges.
 
 ### Setup
 
-If you haven't installed Encord Active, visit [installation](/installation).
+If you haven't installed Encord Active, visit [installation](../installation).
 In this workflow we will be using the BDD validation dataset.
 
 ## Data outliers


### PR DESCRIPTION
Fixed:
Two broken links in the active learning section and one in the workflows section.