### PR TITLE
Fix : Default UseState

### DIFF
--- a/src/encord_active/app/common/state_hooks.py
+++ b/src/encord_active/app/common/state_hooks.py
@@ -69,4 +69,4 @@ class UseState(Generic[T]):
 
     @property
     def value(self) -> T:
-        return st.session_state.get(StateKey.SCOPED, {}).get(self._key) or self._initial
+        return st.session_state.get(StateKey.SCOPED, {}).get(self._key, self._initial)


### PR DESCRIPTION
if the state value is `False` it was returning the initial value