### PR TITLE
updating checkout action version - it use new github env vars

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,10 +12,10 @@ jobs:
     name: Linting and type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup root poetry environment
         uses: ./.github/actions/setup-root-poetry-environment
       - name: Run linting, type checking and testing
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: "--all-files --hook-stage=push"


### PR DESCRIPTION
Making sure that our pipeline is using latest actions which use new GitHub env vars as old will soon the removed.