### PR TITLE
feat: enable exported projects to work properly with prisma db

### DIFF
--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -24,6 +24,7 @@ from encord_active.lib.db.helpers.tags import all_tags
 from encord_active.lib.db.merged_metrics import MergedMetrics
 from encord_active.lib.db.tags import TagScope
 from encord_active.lib.encord.actions import DatasetUniquenessError, EncordActions
+from encord_active.lib.metrics.utils import load_metric_dataframe
 from encord_active.lib.project.metadata import ProjectNotFound
 
 
@@ -456,6 +457,12 @@ def render_export_button(
             return
         project_creation_result = create_and_sync_remote_project(action_utils, cols, df)
         if project_creation_result:
+            # Clean summaries' cache to avoid hit old data hashes
+            get_state().metrics_data_summary = None
+            get_state().metrics_label_summary = None
+            load_metric_dataframe.cache_clear()
+            get_state().project_paths.cache_clear()
+
             new_project_link = f"https://app.encord.com/projects/view/{project_creation_result.project_hash}/summary"
             new_dataset_link = f"https://app.encord.com/datasets/view/{project_creation_result.dataset_hash}"
             update_items = [

--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -436,8 +436,10 @@ def render_export_button(
     render_col.button(
         "🏗 Export to Encord",
         on_click=lambda: current_form.set(CurrentForm.EXPORT),  # type: ignore
-        disabled=True,
-        help="Contact Encord",
+        disabled=not action_utils or is_filtered,
+        help="Export to an Encord dataset and project"
+        if not is_filtered
+        else "Export is allowed only for entire datasets, create a subset first or remove all filters",
     )
     if current_form.value == CurrentForm.EXPORT:
         df = get_state().merged_metrics

--- a/src/encord_active/lib/common/utils.py
+++ b/src/encord_active/lib/common/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -36,6 +38,38 @@ from encord_active.lib.labels.object import BoxShapes, ObjectShape, SimpleShapes
 # Silence shapely deprecation warnings from v1.* to v2.0
 warnings.filterwarnings("ignore", category=ShapelyDeprecationWarning)
 from encord_active.lib.coco.datastructure import CocoBbox
+
+
+class DataHashMapping:
+    _mapping: dict[str, str]
+    _inverse_mapping: dict[str, str]
+
+    def __init__(self):
+        self._mapping = dict()
+        self._inverse_mapping = dict()
+
+    def __contains__(self, data_hash: str):
+        return data_hash in self._mapping
+
+    def __len__(self):
+        return len(self._mapping)
+
+    def set(self, from_hash: str, to_hash: str):
+        self._mapping[from_hash] = to_hash
+        self._inverse_mapping[to_hash] = from_hash
+
+    def get(self, from_hash: str, inverse: bool = False):
+        return self._mapping[from_hash] if not inverse else self._inverse_mapping[from_hash]
+
+    def keys(self, inverse: bool = False):
+        return self._mapping.keys() if not inverse else self._inverse_mapping.keys()
+
+    def items(self, inverse: bool = False):
+        return self._mapping.items() if not inverse else self._inverse_mapping.items()
+
+    def update(self, other: DataHashMapping):
+        self._mapping.update(other._mapping)
+        self._inverse_mapping.update(other._inverse_mapping)
 
 
 def load_json(json_file: Path) -> Optional[dict]:

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -105,7 +105,7 @@ class EncordActions:
         label_row = json.loads(label_row_structure.label_row_file.expanduser().read_text())
 
         if label_row["data_type"] == DataType.IMAGE.value:
-            data_unit_hash = next(label_row["data_units"], None)  # There is only one data unit in an image (type)
+            data_unit_hash = next(iter(label_row["data_units"]), None)  # There is only one data unit in an image (type)
             if data_unit_hash is not None and data_unit_hash in data_unit_hashes:
                 image_path = list(label_row_structure.images_dir.glob(f"{data_unit_hash}.*"))[0]
                 new_lr_data_hash = dataset.upload_image(
@@ -144,7 +144,7 @@ class EncordActions:
                 return new_du_hash_to_original_mapping
 
         elif label_row["data_type"] == DataType.VIDEO.value:
-            data_unit_hash = next(label_row["data_units"], None)  # There is only one data unit in a video (type)
+            data_unit_hash = next(iter(label_row["data_units"]), None)  # There is only one data unit in a video (type)
             if data_unit_hash is not None and data_unit_hash in data_unit_hashes:
                 video_path = list(label_row_structure.images_dir.glob(f"{data_unit_hash}.*"))[0].as_posix()
 

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -18,10 +18,17 @@ from encord.orm.project import (
     ReviewApprovalState,
 )
 from encord.utilities.label_utilities import construct_answer_dictionaries
+from prisma.types import (
+    DataUnitUpdateManyMutationInput,
+    DataUnitWhereInput,
+    LabelRowUpdateInput,
+    _LabelRowWhereUnique_data_hash_Input,
+)
 from tqdm import tqdm
 
 from encord_active.app.common.state import get_state
-from encord_active.lib.common.utils import try_execute
+from encord_active.lib.common.utils import DataHashMapping, try_execute
+from encord_active.lib.db.connection import PrismaConnection
 from encord_active.lib.encord.project_sync import (
     LabelRowDataUnit,
     copy_filtered_data,
@@ -34,7 +41,7 @@ from encord_active.lib.encord.project_sync import (
     replace_uids,
 )
 from encord_active.lib.encord.utils import get_client
-from encord_active.lib.project import ProjectFileStructure
+from encord_active.lib.project import Project, ProjectFileStructure
 from encord_active.lib.project.metadata import fetch_project_meta, update_project_meta
 
 
@@ -42,6 +49,8 @@ class DatasetCreationResult(NamedTuple):
     hash: str
     du_original_mapping: dict[str, LabelRowDataUnit]
     lr_du_mapping: dict[LabelRowDataUnit, LabelRowDataUnit]
+    new_du_hash_to_original_mapping: DataHashMapping
+    new_lr_data_hash_to_original_mapping: DataHashMapping
 
 
 class ProjectCreationResult(NamedTuple):
@@ -90,8 +99,8 @@ class EncordActions:
         dataset: Dataset,
         label_row_hash: str,
         data_unit_hashes: set[str],
-        new_lr_data_hash_to_original: dict[str, str],
-    ) -> Optional[dict[str, str]]:
+        new_lr_data_hash_to_original_mapping: DataHashMapping,
+    ) -> Optional[DataHashMapping]:
         label_row_structure = self.project_file_structure.label_row_structure(label_row_hash)
         label_row = json.loads(label_row_structure.label_row_file.expanduser().read_text())
 
@@ -102,9 +111,11 @@ class EncordActions:
                 new_lr_data_hash = dataset.upload_image(
                     file_path=image_path, title=label_row["data_units"][data_unit_hash]["data_title"]
                 )["data_hash"]
+                new_lr_data_hash_to_original_mapping.set(new_lr_data_hash, label_row["data_hash"])
                 # The data unit hash and label row data hash of an image (type) are the same
-                new_lr_data_hash_to_original[new_lr_data_hash] = label_row["data_hash"]
-                return {new_lr_data_hash: data_unit_hash}
+                new_du_hash_to_original_mapping = DataHashMapping()
+                new_du_hash_to_original_mapping.set(new_lr_data_hash, data_unit_hash)
+                return new_du_hash_to_original_mapping
 
         elif label_row["data_type"] == DataType.IMG_GROUP.value:
             image_paths = []
@@ -122,28 +133,31 @@ class EncordActions:
                 dataset.create_image_group(file_paths=image_paths, title=label_row["data_title"])
                 # Since `create_image_group()` does not return info related to the uploaded images,
                 # we need to find the data hash of the image group in a hacky way
-                new_data_row: DataRow = _find_new_data_row(dataset, new_lr_data_hash_to_original)
-                new_lr_data_hash_to_original[new_data_row.uid] = label_row["data_hash"]
+                new_data_row: DataRow = _find_new_data_row(dataset, new_lr_data_hash_to_original_mapping)
+                new_lr_data_hash_to_original_mapping.set(new_data_row.uid, label_row["data_hash"])
 
                 # Obtain the data unit hashes of the images contained in the image group
                 new_data_row.refetch_data(images_data_fetch_options=ImagesDataFetchOptions(fetch_signed_urls=False))
-                return {
-                    new_data_row.images_data[i].image_hash: sorted_data_units[i]["data_hash"]
-                    for i in range(len(sorted_data_units))
-                }
+                new_du_hash_to_original_mapping = DataHashMapping()
+                for i, data_unit in enumerate(sorted_data_units):
+                    new_du_hash_to_original_mapping.set(new_data_row.images_data[i].image_hash, data_unit["data_hash"])
+                return new_du_hash_to_original_mapping
 
         elif label_row["data_type"] == DataType.VIDEO.value:
             data_unit_hash = next(label_row["data_units"], None)  # There is only one data unit in a video (type)
             if data_unit_hash is not None and data_unit_hash in data_unit_hashes:
                 video_path = list(label_row_structure.images_dir.glob(f"{data_unit_hash}.*"))[0].as_posix()
 
+                dataset.upload_video(file_path=video_path, title=label_row["data_units"][data_unit_hash]["data_title"])
                 # Since `upload_video()` does not return info related to the uploaded video,
                 # we need to find the data hash of the video in a hacky way
-                dataset.upload_video(file_path=video_path, title=label_row["data_units"][data_unit_hash]["data_title"])
+                new_data_row = _find_new_data_row(dataset, new_lr_data_hash_to_original_mapping)
+                new_lr_data_hash_to_original_mapping.set(new_data_row.uid, label_row["data_hash"])
+
                 # The data unit hash and label row data hash of a video (type) are the same
-                new_data_row = _find_new_data_row(dataset, new_lr_data_hash_to_original)
-                new_lr_data_hash_to_original[new_data_row.uid] = label_row["data_hash"]
-                return {new_data_row.uid: data_unit_hash}
+                new_du_hash_to_original_mapping = DataHashMapping()
+                new_du_hash_to_original_mapping.set(new_data_row.uid, data_unit_hash)
+                return new_du_hash_to_original_mapping
 
         else:
             raise Exception(f'Undefined data type {label_row["data_type"]} for label_row={label_row["label_hash"]}')
@@ -180,34 +194,41 @@ class EncordActions:
 
         total_amount_of_data_units: int = sum(map(len, label_hash_to_data_units.values()))
         current_number_of_uploaded_data_units: int = 0
-        new_lr_data_hash_to_original: dict[str, str] = dict()
+        new_du_hash_to_original_mapping = DataHashMapping()
+        new_lr_data_hash_to_original_mapping = DataHashMapping()
         for label_row_hash, data_hashes in label_hash_to_data_units.items():
-            new_du_hashes_to_original: Optional[dict[str, str]] = try_execute(
+            output_new_du_hash_to_original_mapping: Optional[DataHashMapping] = try_execute(
                 self._upload_label_row,
                 5,
                 {
                     "dataset": dataset,
                     "label_row_hash": label_row_hash,
                     "data_unit_hashes": data_hashes,
-                    "new_lr_data_hash_to_original": new_lr_data_hash_to_original,
+                    "new_lr_data_hash_to_original_mapping": new_lr_data_hash_to_original_mapping,
                 },
             )
-            if new_du_hashes_to_original is None:
+            if output_new_du_hash_to_original_mapping is None:
                 raise Exception("Data upload failed")
 
-            for new_data_unit_hash, data_unit_hash in new_du_hashes_to_original.items():
+            for new_data_unit_hash, data_unit_hash in output_new_du_hash_to_original_mapping.items():
                 new_du_to_original[new_data_unit_hash] = LabelRowDataUnit(label_row_hash, data_unit_hash)
                 # TODO: check if lrdu_mapping without label row's data hash works ok for image groups (old behaviour)
                 lrdu_mapping[LabelRowDataUnit(label_row_hash, data_unit_hash)] = LabelRowDataUnit(
                     "", new_data_unit_hash
                 )
 
-            # Advance progress bar
-            current_number_of_uploaded_data_units += len(new_du_hashes_to_original)
+            # Update global data unit mapping and advance progress bar
+            new_du_hash_to_original_mapping.update(output_new_du_hash_to_original_mapping)
             if progress_callback:
-                progress_callback(current_number_of_uploaded_data_units / total_amount_of_data_units)
+                progress_callback(len(new_du_hash_to_original_mapping) / total_amount_of_data_units)
 
-        return DatasetCreationResult(dataset_hash, new_du_to_original, lrdu_mapping)
+        return DatasetCreationResult(
+            dataset_hash,
+            new_du_to_original,
+            lrdu_mapping,
+            new_du_hash_to_original_mapping,
+            new_lr_data_hash_to_original_mapping,
+        )
 
     def create_ontology(self, title: str, description: str):
         ontology_dict = json.loads(self.project_file_structure.ontology.read_text(encoding="utf-8"))
@@ -304,6 +325,8 @@ class EncordActions:
             new_project.project_hash,
             dataset_creation_result.hash,
         )
+
+        replace_db_uids(self.project_file_structure, dataset_creation_result)
 
         return new_project
 
@@ -434,10 +457,10 @@ class EncordActions:
         return cloned_project_hash
 
 
-def _find_new_data_row(dataset: Dataset, out_mapping: dict) -> Optional[DataRow]:
+def _find_new_data_row(dataset: Dataset, mapping: DataHashMapping) -> Optional[DataRow]:
     dataset.refetch_data()  # ensure the dataset instance include the latest changes
     for data_row in dataset.data_rows:
-        if data_row["data_hash"] not in out_mapping:
+        if data_row["data_hash"] not in mapping:
             return data_row
     return None
 
@@ -465,3 +488,21 @@ class DatasetUniquenessError(Exception):
         super().__init__(
             f"Dataset title '{dataset_title}' already exists in your list of datasets at Encord. Please use a different title."
         )
+
+
+def replace_db_uids(project_file_structure: ProjectFileStructure, dataset_creation_result: DatasetCreationResult):
+    # Update the data hash changes in the DataUnit and LabelRow db tables
+    with PrismaConnection(project_file_structure) as conn:
+        with conn.batch_() as batcher:
+            for new_du_hash, du_hash in dataset_creation_result.new_du_hash_to_original_mapping.items():
+                batcher.dataunit.update_many(
+                    where=DataUnitWhereInput(data_hash=du_hash),
+                    data=DataUnitUpdateManyMutationInput(data_hash=new_du_hash),
+                )
+            for new_lr_data_hash, lr_data_hash in dataset_creation_result.new_lr_data_hash_to_original_mapping.items():
+                batcher.labelrow.update(
+                    where=_LabelRowWhereUnique_data_hash_Input(data_hash=lr_data_hash),
+                    data=LabelRowUpdateInput(data_hash=new_lr_data_hash),
+                )
+            batcher.commit()
+    Project(project_file_structure.project_dir).refresh()

--- a/src/encord_active/lib/encord/local_sdk.py
+++ b/src/encord_active/lib/encord/local_sdk.py
@@ -136,6 +136,7 @@ def get_empty_label_row(meta: LabelRowMetadata, dr: LocalDataRow, dataset_title:
             "dataset_hash": meta.dataset_hash,
             "dataset_title": dataset_title,
             "data_title": meta.data_title,
+            "data_hash": meta.data_hash,
             "data_type": "image",
             "data_units": data_units,
             "object_answers": {},

--- a/src/encord_active/lib/file_structure/base.py
+++ b/src/encord_active/lib/file_structure/base.py
@@ -12,6 +12,13 @@ class BaseProjectFileStructure:
             project_dir = Path(project_dir)
         self.project_dir: Path = project_dir.expanduser().resolve()
 
+    @abstractmethod
+    def cache_clear(self) -> None:
+        """
+        Clear any cached data and fetch the latest changes.
+        """
+        pass
+
     @property
     @abstractmethod
     def data(self) -> Path:

--- a/src/encord_active/lib/project/project_file_structure.py
+++ b/src/encord_active/lib/project/project_file_structure.py
@@ -120,6 +120,9 @@ class ProjectFileStructure(BaseProjectFileStructure):
         super().__init__(project_dir)
         self._mappings = json.loads(self.mappings.read_text()) if self.mappings.exists() else {}
 
+    def cache_clear(self) -> None:
+        self._mappings = json.loads(self.mappings.read_text()) if self.mappings.exists() else {}
+
     @property
     def data(self) -> Path:
         return self.project_dir / "data"


### PR DESCRIPTION
Changes include:
1. Addition of `DataHashMapping` class to ease the overall process of storing mappings while allowing easy comprehension on what's being done (avoid passing dicts every time).
2. Change db's data hashes for the new ones that result from the `Export to Encord` feature.
3. Enable the `Export to Encord` feature.