### PR TITLE
feat: add send labels to annotation stage

### DIFF
--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -300,16 +300,14 @@ def actions():
         export_button_col,
         subset_button_col,
         delete_button_col,
-        edit_button_col,
+        relabel_button_col,
         augment_button_col,
     ) = st.columns((3, 3, 3, 3, 2, 2, 2))
     file_prefix = get_state().project_paths.project_dir.name
 
     render_generate_csv(generate_csv_col, file_prefix, filtered_df)
     render_generate_coco(generate_coco_col, file_prefix, filtered_df)
-    render_unimplemented_buttons(
-        delete_button_col, edit_button_col, augment_button_col, message_placeholder, current_form.set
-    )
+    render_unimplemented_buttons(delete_button_col, augment_button_col, message_placeholder, current_form.set)
 
     if filtered_row_count.value != row_count:
         filtered_row_count.set(row_count)
@@ -475,7 +473,6 @@ def render_export_button(
 
 def render_unimplemented_buttons(
     delete_button_column: DeltaGenerator,
-    edit_button_column: DeltaGenerator,
     augment_button_column: DeltaGenerator,
     message_placeholder: DeltaGenerator,
     set_current_form: Callable,
@@ -483,11 +480,8 @@ def render_unimplemented_buttons(
     delete_btn = delete_button_column.button(
         "👀 Review", help="Assign the filtered data for review on the Encord platform"
     )
-    edit_btn = edit_button_column.button(
-        "🖋 Re-label", help="Assign the filtered data for relabelling on the Encord platform"
-    )
     augment_btn = augment_button_column.button("➕ Augment", help="Augment your dataset based on the filtered data")
-    if any([delete_btn, edit_btn, augment_btn]):
+    if any([delete_btn, augment_btn]):
         set_current_form(CurrentForm.NONE)
         message_placeholder.markdown(
             f"""

--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -588,7 +588,7 @@ def render_relabel_button(
     if relabel_data:
         with st.spinner(text="Sending data to relabel"):
             # Get the label row to send to relabel
-            lr_hashes = set(str(identifier).split(maxsplit=1)[0] for identifier in filtered_df["identifier"].to_list())
+            lr_hashes = set(str(_id).split("_", maxsplit=1)[0] for _id in filtered_df["identifier"].to_list())
 
             encord_project = get_encord_project(project_meta["ssh_key_path"], project_meta["project_hash"])
 

--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -563,20 +563,20 @@ def render_relabel_button(
     # Check the conditions to be able to send the filtered data back to labeling on Encord (remote project)
     is_disabled = False
     extra_help_text = ""
-    if not project_meta.get("has_remote", True):
+    if not project_meta.get("has_remote", False):
         # Local projects
         is_disabled = True
         extra_help_text = (
-            " The current project is local so it doesn't support data relabeling."
-            "Please, first export the project to the Encord platform."
+            " Relabeling is only supported on workflow projects and this project is local."
+            " Please, first export the data to a workflow project in the Encord platform."
         )
 
-    elif len(label_row_meta) == 0 or next(iter(label_row_meta.values())).get("workflow_graph_node") is not None:
+    elif len(label_row_meta) == 0 or next(iter(label_row_meta.values())).get("workflow_graph_node") is None:
         # Non-workflow projects
         is_disabled = True
         extra_help_text = (
             " Relabeling is only supported on workflow projects."
-            "Please, first upgrade your project so it uses workflows."
+            " Please, first upgrade your project so it uses workflows."
         )
 
     relabel_placeholder = render_column.empty()

--- a/src/encord_active/cli/print.py
+++ b/src/encord_active/cli/print.py
@@ -28,9 +28,10 @@ def print_encord_projects(
     > encord-active print encord-projects --query "%validation%"
 
     """
-    from encord_active.lib.encord.utils import get_projects_json
+    from encord_active.lib.encord.utils import ProjectQuery, get_projects_json
 
-    json_projects = get_projects_json(app_config.get_or_query_ssh_key(), query={"title_like": query})
+    project_query = None if query is None else ProjectQuery(title_like=query)
+    json_projects = get_projects_json(app_config.get_or_query_ssh_key(), project_query)
     if state.get("json_output"):
         Path("./encord-projects.json").write_text(json_projects, encoding="utf-8")
     else:

--- a/src/encord_active/cli/print.py
+++ b/src/encord_active/cli/print.py
@@ -30,7 +30,7 @@ def print_encord_projects(
     """
     from encord_active.lib.encord.utils import get_projects_json
 
-    json_projects = get_projects_json(app_config.get_or_query_ssh_key(), query)
+    json_projects = get_projects_json(app_config.get_or_query_ssh_key(), query={"title_like": query})
     if state.get("json_output"):
         Path("./encord-projects.json").write_text(json_projects, encoding="utf-8")
     else:

--- a/src/encord_active/lib/encord/utils.py
+++ b/src/encord_active/lib/encord/utils.py
@@ -25,6 +25,11 @@ def get_client(ssh_key_path: Path):
     )
 
 
+def get_encord_project(ssh_key_path: Path, project_hash: str):
+    client = get_client(ssh_key_path)
+    return client.get_project(project_hash)
+
+
 def get_encord_projects(ssh_key_path: Path, query: Optional[dict] = None) -> List[Project]:
     client = get_client(ssh_key_path)
     if query is None:  # Get all projects

--- a/src/encord_active/lib/encord/utils.py
+++ b/src/encord_active/lib/encord/utils.py
@@ -25,7 +25,9 @@ def get_client(ssh_key_path: Path):
     )
 
 
-def get_encord_project(ssh_key_path: Path, project_hash: str):
+def get_encord_project(ssh_key_path: Union[str, Path], project_hash: str):
+    if isinstance(ssh_key_path, str):
+        ssh_key_path = Path(ssh_key_path)
     client = get_client(ssh_key_path)
     return client.get_project(project_hash)
 

--- a/src/encord_active/lib/encord/utils.py
+++ b/src/encord_active/lib/encord/utils.py
@@ -25,13 +25,15 @@ def get_client(ssh_key_path: Path):
     )
 
 
-def get_encord_projects(ssh_key_path: Path, query: Optional[str] = None) -> List[Project]:
+def get_encord_projects(ssh_key_path: Path, query: Optional[dict] = None) -> List[Project]:
     client = get_client(ssh_key_path)
-    projects: List[Project] = list(map(lambda x: x["project"], client.get_projects(title_like=query)))
+    if query is None:  # Get all projects
+        query = dict()
+    projects: List[Project] = list(map(lambda x: x["project"], client.get_projects(**query)))
     return projects
 
 
-def get_projects_json(ssh_key_path: Path, query: Optional[str] = None) -> str:
+def get_projects_json(ssh_key_path: Path, query: Optional[dict] = None) -> str:
     projects = get_encord_projects(ssh_key_path, query)
     return json_dumps({p.project_hash: p.title for p in projects}, indent=2)
 

--- a/src/encord_active/lib/encord/utils.py
+++ b/src/encord_active/lib/encord/utils.py
@@ -1,7 +1,8 @@
 import uuid
+from datetime import datetime
 from json import dumps as json_dumps
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
 from encord import EncordUserClient
 from encord.http.constants import RequestsSettings
@@ -18,6 +19,17 @@ from encord_active.lib.labels.object import BoxShapes, ObjectShape
 BBOX_KEYS = {"x", "y", "h", "w"}
 
 
+class ProjectQuery(TypedDict, total=False):
+    title_eq: str
+    title_like: str
+    desc_eq: str
+    desc_like: str
+    created_before: Union[str, datetime]
+    created_after: Union[str, datetime]
+    edited_before: Union[str, datetime]
+    edited_after: Union[str, datetime]
+
+
 def get_client(ssh_key_path: Path):
     return EncordUserClient.create_with_ssh_private_key(
         ssh_key_path.read_text(encoding="utf-8"),
@@ -32,15 +44,15 @@ def get_encord_project(ssh_key_path: Union[str, Path], project_hash: str):
     return client.get_project(project_hash)
 
 
-def get_encord_projects(ssh_key_path: Path, query: Optional[dict] = None) -> List[Project]:
+def get_encord_projects(ssh_key_path: Path, query: Optional[ProjectQuery] = None) -> List[Project]:
     client = get_client(ssh_key_path)
     if query is None:  # Get all projects
-        query = dict()
+        query = ProjectQuery()
     projects: List[Project] = list(map(lambda x: x["project"], client.get_projects(**query)))
     return projects
 
 
-def get_projects_json(ssh_key_path: Path, query: Optional[dict] = None) -> str:
+def get_projects_json(ssh_key_path: Path, query: Optional[ProjectQuery] = None) -> str:
     projects = get_encord_projects(ssh_key_path, query)
     return json_dumps({p.project_hash: p.title for p in projects}, indent=2)
 


### PR DESCRIPTION
Now workflow projects have an integration which allows to send labels back to the annotation stage.
It recognises when a project is not a workflow project and provides information to the user about the next steps to make feature work.
It works nicely but still needs a progress bar, a confirmation pop up as it's very easy to send everything back to the labelling step if no filter has been selected which could cause a major issue and also register these operations in logs so in case the user mess up and wants to revert the mistake, (s)he can do so without having a backup copy of the project.