### PR TITLE
fix: coco bbox default no rotation

### DIFF
--- a/src/encord_active/lib/embeddings/cnn.py
+++ b/src/encord_active/lib/embeddings/cnn.py
@@ -149,7 +149,6 @@ def generate_cnn_object_embeddings(iterator: Iterator) -> List[LabelEmbedding]:
                 ObjectShape.BOUNDING_BOX.value,
                 ObjectShape.ROTATABLE_BOUNDING_BOX.value,
             ]:
-
                 last_edited_by = obj["lastEditedBy"] if "lastEditedBy" in obj.keys() else obj["createdBy"]
 
                 entry = LabelEmbedding(
@@ -216,7 +215,6 @@ def generate_cnn_classification_embeddings(iterator: Iterator) -> List[LabelEmbe
 
         classification_answers = iterator.label_rows[iterator.label_hash]["classification_answers"]
         for classification in data_unit["labels"].get("classifications", []):
-
             last_edited_by = (
                 classification["lastEditedBy"]
                 if "lastEditedBy" in classification.keys()

--- a/src/encord_active/lib/encord/utils.py
+++ b/src/encord_active/lib/encord/utils.py
@@ -139,7 +139,7 @@ def make_object_dict(
             raise ValueError(f"The `object_data` for {shape} should float values.")
 
         box = {k: round(v, 4) for k, v in object_data.items()}
-        if shape == ObjectShape.ROTATABLE_BOUNDING_BOX:
+        if shape.value == ObjectShape.ROTATABLE_BOUNDING_BOX:
             if "theta" not in object_data:
                 raise ValueError(f"The `object_data` for {shape} should contain a `theta` field.")
 


### PR DESCRIPTION
When importing coco annotations from, e.g., CVAT, they will have a "angle" property set to 0. If all labels have angle 0, use regular bboxes instead of rotational ones. 