### PR TITLE
fix: data tags interaction with labels in the label explorer

### DIFF
--- a/src/encord_active/lib/db/helpers/tags.py
+++ b/src/encord_active/lib/db/helpers/tags.py
@@ -49,7 +49,7 @@ def to_grouped_tags(tags: List[Tag]) -> GroupedTags:
     return grouped_tags
 
 
-def from_grouped_tags(tags: GroupedTags) -> List[Tag]:
+def from_grouped_tags(tags: GroupedTags) -> tuple[List[Tag], List[Tag]]:
     data_tags = [Tag(tag, TagScope.DATA) for tag in tags["data"]]
     label_tags = [Tag(tag, TagScope.LABEL) for tag in tags["label"]]
-    return [*data_tags, *label_tags]
+    return data_tags, label_tags

--- a/src/encord_active/server/routers/project.py
+++ b/src/encord_active/server/routers/project.py
@@ -64,6 +64,13 @@ def read_item(project: ProjectFileStructureDep, id: str):
     with DBConnection(project) as conn:
         row = MergedMetrics(conn).get_row(id).dropna(axis=1).to_dict("records")[0]
 
+        # Include data tags from the relevant frame when the inspected item is a label
+        if len(row["identifier"].split("_")) > 3:
+            data_row_id = "_".join(row["identifier"].split("_", maxsplit=3)[:3])
+            data_row = MergedMetrics(conn).get_row(data_row_id).dropna(axis=1).to_dict("records")[0]
+            selected_tags = row.setdefault("tags", [])
+            selected_tags.extend(data_row.get("tags", []))
+
     return to_item(row, project, lr_hash, du_hash, frame)
 
 


### PR DESCRIPTION
The labels in the label explorer were missing the data tags from the respective frames. Now, it's possible to visualise the tags applied over the frame where the label is and any modification to the data tags in the label explorer is reflected application wide.