### PR TITLE
Adding SAMEORIGIN on hosted EA to prevent clickjacking

### DIFF
--- a/docs/firebase.json
+++ b/docs/firebase.json
@@ -10,6 +10,21 @@
           "destination": "/",
           "type": 301
         }
+      ],
+       "headers": [
+        {
+          "source": "**/*",
+          "headers": [
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "SAMEORIGIN"
+            }
+          ]
+        }
       ]
     }
   ]


### PR DESCRIPTION
Adding SAMEORIGIN on hosted EA to prevent clickjacking but allow exposure via iFrame in Encord app