### PR TITLE
fix: coco prediction segmentations with nested lists

### DIFF
--- a/src/encord_active/lib/coco/parsers.py
+++ b/src/encord_active/lib/coco/parsers.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+import numpy as np
 from tqdm.auto import tqdm
 
 from encord_active.lib.coco.datastructure import (
@@ -107,11 +108,13 @@ def parse_annotations(annotations: List[Dict]) -> Dict[int, List[CocoAnnotation]
 def parse_results(results: List[Dict]):
     coco_results: List[CocoResult] = []
     for result in tqdm(results, desc="Parsing results"):
-        segmentations = result["segmentation"]
+        segmentations = result.get("segmentation")
         bbox = result.get("bbox")
 
-        if isinstance(segmentations, list) and not isinstance(segmentations[0], list):
-            segmentations = [segmentations]
+        if isinstance(segmentations, list):
+            if not isinstance(segmentations[0], list):
+                segmentations = [segmentations]
+            segmentations = [np.array(s).reshape(-1, 2).tolist() for s in segmentations]
         elif isinstance(segmentations, dict):
             h, w = segmentations["size"]
             mask = annToMask(result, h=h, w=w)


### PR DESCRIPTION
Prediction import fails if the predictions have nested segmentations:
```json
[
  {
    "id": 1,
    "image_id": 1,
    "category_id": 1,
    "score": 0.9,
    "segmentation": [
      [
        577, 337, 577, 336, 578, 335, 578, 334
      ],
      ...
    ],
    "bbox": [587.0, 343.0, 40.0, 32.0],
    "area": 18.0,
    "iscrowd": 0
  }
]
```
This PR should fix that.