### PR TITLE
fix: exception when premium search disabled

### DIFF
--- a/src/encord_active/app/model_quality/prediction_types/classification_type_builder.py
+++ b/src/encord_active/app/model_quality/prediction_types/classification_type_builder.py
@@ -191,7 +191,7 @@ class ClassificationTypeBuilder(PredictionTypeBuilder):
             help="Only available for premium version",
         )
 
-        if magic_prompt != "":
+        if magic_prompt != "" and not is_disabled:
             selected_ids = list(self._model_predictions[ClassificationPredictionMatchSchemaWithClassNames.identifier])
             result = querier.search_with_code_on_dataframe(TextQuery(identifiers=selected_ids, text=magic_prompt))
 


### PR DESCRIPTION
Non-premium views of the page display an connection error. This will only execute the querier when the feature is not disabled.