### PR TITLE
Fix (project creation): remove project folder properly

### DIFF
--- a/src/encord_active/app/actions_page/export_filter.py
+++ b/src/encord_active/app/actions_page/export_filter.py
@@ -212,7 +212,7 @@ def _get_column(col: DeltaGenerator, item: str, num_rows: int, subset: bool, pro
     return InputItem(
         col.text_input(
             f"{item} title",
-            value=f"{'Subset: ' if subset else ''}{project_name} ({num_rows})",
+            value=f"{'Subset ' if subset else ''}{project_name} ({num_rows})",
         ),
         col.text_area(f"{item} description"),
     )

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -408,7 +408,7 @@ class EncordActions:
                 )
 
         except Exception as e:
-            shutil.rmtree(target_project_dir.as_posix())
+            os.removedirs(target_project_dir.as_posix())
             raise e
         return target_project_structure.project_dir
 

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -408,7 +408,7 @@ class EncordActions:
                 )
 
         except Exception as e:
-            os.removedirs(target_project_dir.as_posix())
+            shutil.rmtree(target_project_dir.as_posix())
             raise e
         return target_project_structure.project_dir
 

--- a/src/encord_active/lib/encord/actions.py
+++ b/src/encord_active/lib/encord/actions.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import tempfile
 from pathlib import Path


### PR DESCRIPTION
Basically, after creating some files in the newly created folder, if an error happens, `os.removedirs()` cannot delete them.