### PR TITLE
fix: update built-in metrics' locations

### DIFF
--- a/src/encord_active/lib/metrics/metadata.py
+++ b/src/encord_active/lib/metrics/metadata.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from encord_active.lib.metrics.io import fill_metrics_meta_with_builtin_metrics
 from encord_active.lib.project import ProjectFileStructure
@@ -6,11 +7,18 @@ from encord_active.lib.project import ProjectFileStructure
 
 def fetch_metrics_meta(project_file_structure: ProjectFileStructure):
     meta_file = project_file_structure.metrics_meta
-    if not meta_file.is_file():
-        metrics = fill_metrics_meta_with_builtin_metrics()
-        update_metrics_meta(project_file_structure, metrics)
+    builtin_metrics = fill_metrics_meta_with_builtin_metrics()
 
-    return json.loads(meta_file.read_text(encoding="utf-8"))
+    if not meta_file.is_file():
+        metrics_meta = builtin_metrics
+    else:
+        metrics_meta = json.loads(meta_file.read_text(encoding="utf-8"))
+        for metric_title in builtin_metrics:
+            if metric_title in metrics_meta and not Path(metrics_meta[metric_title]["location"]).exists():
+                metrics_meta[metric_title] = builtin_metrics[metric_title]
+
+    update_metrics_meta(project_file_structure, metrics_meta)  # Update refreshed metric locations
+    return metrics_meta
 
 
 def update_metrics_meta(project_file_structure: ProjectFileStructure, updated_meta: dict):


### PR DESCRIPTION
Handle the case where the original location of the built-in metrics doesn't longer exist, so we use the location of the active EA package.