### PR TITLE
fix: limit opened file descriptors

### DIFF
--- a/src/encord_active/lib/common/data_utils.py
+++ b/src/encord_active/lib/common/data_utils.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor as Executor
 from concurrent.futures import as_completed
 from io import BytesIO
 from pathlib import Path
-from typing import IO, Callable, Dict, Generator, Optional, Sequence, TypeVar
+from typing import Callable, Dict, Generator, Optional, Sequence, TypeVar
 from urllib.parse import unquote, urlparse
 
 import numpy as np


### PR DESCRIPTION
Minimise the number of open file descriptors for the temp cache implementation. As this seems to be the root cause behind the connectivity issues.