### PR TITLE
fix: perf improvements, don't download images twice.

### DIFF
--- a/src/encord_active/lib/metrics/geometric/image_border_closeness.py
+++ b/src/encord_active/lib/metrics/geometric/image_border_closeness.py
@@ -1,3 +1,4 @@
+import numpy as np
 from loguru import logger
 
 from encord_active.lib.common.iterator import Iterator
@@ -41,15 +42,12 @@ class ImageBorderCloseness(Metric):
                 if not coordinates:  # avoid corrupted objects without vertices ([]) and unknown objects' shape (None)
                     continue
 
-                x_coordinates = [x for x, _ in coordinates]
-                min_x = min(x_coordinates)
-                max_x = max(x_coordinates)
+                np_coordinates: np.ndarray = np.array(coordinates, dtype=np.single)
+                np_max = np.max(np_coordinates, axis=0)
+                np_min = 1.0 - np.min(np_coordinates, axis=0)
 
-                y_coordinates = [y for _, y in coordinates]
-                min_y = min(y_coordinates)
-                max_y = max(y_coordinates)
-
-                score = max(1 - min_x, 1 - min_y, max_x, max_y)
+                # Equivalent: score = max(1 - min_x, 1 - min_y, max_x, max_y)
+                score = max(np.max(np_max), np.max(np_min))
                 writer.write(score, obj)
                 found_any = True
 

--- a/src/encord_active/lib/metrics/geometric/image_border_closeness.py
+++ b/src/encord_active/lib/metrics/geometric/image_border_closeness.py
@@ -48,7 +48,7 @@ class ImageBorderCloseness(Metric):
 
                 # Equivalent: score = max(1 - min_x, 1 - min_y, max_x, max_y)
                 score = max(np.max(np_max), np.max(np_min))
-                writer.write(score, obj)
+                writer.write(float(score), obj)
                 found_any = True
 
         if not found_any:

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -6,7 +6,10 @@ import logging
 import tempfile
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    import prisma
 
 import yaml
 from encord import Project as EncordProject
@@ -271,7 +274,7 @@ class Project:
                         download_label_row_and_data,
                         project=project,
                         project_file_structure=project_file_structure,
-                        cache_db=conn
+                        cache_db=conn,
                     ),
                     label_rows_to_download,
                     desc="Collecting new data",
@@ -304,7 +307,9 @@ class Project:
 
 
 def download_label_row(
-    label_hash: str, project: EncordProject, project_file_structure: ProjectFileStructure,
+    label_hash: str,
+    project: EncordProject,
+    project_file_structure: ProjectFileStructure,
     cache_db: Optional["prisma.Prisma"] = None,
 ) -> LabelRow:
     label_row = try_execute(partial(project.get_label_row, get_signed_url=True), 5, {"uid": label_hash})
@@ -335,9 +340,9 @@ def download_label_row(
 
 
 def download_data(
-        label_row: LabelRow,
-        project_file_structure: ProjectFileStructure,
-        cache_db: Optional["prisma.Prisma"] = None,
+    label_row: LabelRow,
+    project_file_structure: ProjectFileStructure,
+    cache_db: Optional["prisma.Prisma"] = None,
 ):
     lr_structure = project_file_structure.label_row_structure(label_row.label_hash)
     data_units = sorted(label_row.data_units.values(), key=lambda du: int(du["data_sequence"]))
@@ -386,7 +391,7 @@ def download_data(
                 data={
                     "width": image.width,
                     "height": image.height,
-                }
+                },
             )
 
 

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -340,22 +340,26 @@ def download_data(label_row: LabelRow, project_file_structure: ProjectFileStruct
         if label_row.data_type == DataType.VIDEO.value:
             return
 
-        image = download_image(du["data_link"])
+        data_hash = du["data_hash"]
+        frame = int(du["data_sequence"])
+        data_unit = next(lr_structure.iter_data_unit(data_unit_hash=data_hash, frame=frame))
+
+        image = download_image(data_unit.signed_url)
 
         # Add non-video type of data to the db
         with PrismaConnection(project_file_structure) as conn:
             conn.dataunit.upsert(
                 where={
                     "data_hash_frame": {  # state the values of the compound key
-                        "data_hash": du["data_hash"],
-                        "frame": int(du["data_sequence"]),
+                        "data_hash": data_hash,
+                        "frame": frame,
                     }
                 },
                 data={
                     "create": {
-                        "data_hash": du["data_hash"],
+                        "data_hash": data_hash,
                         "data_title": du["data_title"],
-                        "frame": int(du["data_sequence"]),
+                        "frame": frame,
                         "lr_data_hash": label_row.data_hash,
                         "fps": 0,
                         "width": image.width,


### PR DESCRIPTION
Perf improvement to evaluation of 1 metric.

Main: performance improvement by assuring that when loading data the same url is used as metric iterations, this ensures that it runs through the same cache logic and hence avoids downloading all images twice.