### PR TITLE
fix (examples): make generic names to avoid confusion

### DIFF
--- a/examples/getting-started-with-coco-project.ipynb
+++ b/examples/getting-started-with-coco-project.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "## 2. Importing a COCO Project\n",
     "\n",
-    "To import a COCO project, you need the root directory of the coco images, e.g., `/path/to/train2017`, and you need the path to the annotations JSON file, e.g., `/path/to/annotations/instances_train2017.json`.\n",
+    "To import a COCO project, you need the root directory of the coco images, e.g., `/path/to/image_dir`, and you need the path to the annotations JSON file, e.g., `/path/to/annotations/annotations.json`.\n",
     "\n",
     "Furthermore, you can optionally specify a `--target`/`-t` which tells Encord Active where to store the data. If you don't specify this, your current working directory will be used.\n",
     "\n",


### PR DESCRIPTION
Use generic names to not confuse users.