### PR TITLE
fix: invalid image paths, use urls instead

### DIFF
--- a/docs/docs/tutorials/touring-the-coco-dataset.mdx
+++ b/docs/docs/tutorials/touring-the-coco-dataset.mdx
@@ -80,7 +80,7 @@ When clicking the button and taking a closer look at the image, you will see tha
 
 <div style={{ textAlign: "center" }}>
   <img
-    src="../../static/img/tutorials/duplicated-annotation-orange.jpeg"
+    src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/tutorials/duplicated-annotation-orange.jpeg"
     alt="Duplicated annotations"
     width={300}
   />
@@ -89,7 +89,7 @@ When clicking the button and taking a closer look at the image, you will see tha
 
 Hit <kbd>esc</kbd> to exit the full screen view.
 
-If you look at the other images displayed, you will notice similar issues.
+If you take a closer look at the annotations in the other displayed images, you will notice the same issue.
 
 <div
   style={{
@@ -101,7 +101,7 @@ If you look at the other images displayed, you will notice similar issues.
 >
   <div style={{ textAlign: "center", display: "table-cell", padding: "5px" }}>
     <img
-      src="../../static/img/tutorials/duplicated-annotation-skiing.jpeg"
+      src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/tutorials/duplicated-annotation-skiing.jpeg"
       alt="Duplicated annotations"
       width={300}
       style={{ display: "block", width: "100%", height: "auto" }}
@@ -109,7 +109,7 @@ If you look at the other images displayed, you will notice similar issues.
   </div>
   <div style={{ textAlign: "center", display: "table-cell", padding: "5px" }}>
     <img
-      src="../../static/img/tutorials/duplicated-annotation-broccoli.jpeg"
+      src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/tutorials/duplicated-annotation-broccoli.jpeg"
       alt="Duplicated annotations"
       width={300}
       style={{ display: "block", width: "100%", height: "auto" }}
@@ -117,7 +117,7 @@ If you look at the other images displayed, you will notice similar issues.
   </div>
   <div style={{ textAlign: "center", display: "table-cell", padding: "5px" }}>
     <img
-      src="../../static/img/tutorials/duplicated-annotation-fridge.jpeg"
+      src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/tutorials/duplicated-annotation-fridge.jpeg"
       alt="Duplicated annotations"
       width={300}
       style={{ display: "block", width: "100%", height: "auto" }}

--- a/docs/docs/user-guide/relabeling.mdx
+++ b/docs/docs/user-guide/relabeling.mdx
@@ -24,7 +24,7 @@ This empowers annotators to address any missing elements and enhance the overall
 <div style={{ display: "flex", justifyContent: "space-around", gap: "2em" }}>
   <div style={{ width: "45%", textAlign: "center" }}>
     <img
-      src="../img/user-guide/workflow-project-summary.png"
+      src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/user-guide/workflow-project-summary.png"
       width="100%"
       alt="workflow-project-summary-before-relabeling.png"
     />
@@ -32,7 +32,7 @@ This empowers annotators to address any missing elements and enhance the overall
   </div>
   <div style={{ width: "45%", textAlign: "center" }}>
     <img
-      src="../img/user-guide/workflow-project-summary-after-relabeling.png"
+      src="https://raw.githubusercontent.com/encord-team/encord-active/main/docs/static/img/user-guide/workflow-project-summary-after-relabeling.png"
       width="100%"
       alt="workflow-project-summary-after-relabeling.png"
     />


### PR DESCRIPTION
When local images are displayed within html tags and the repo is migrated to the main docs, then the resulting paths are invalid.