### PR TITLE
fix: do not use assert to verify deployment token

### DIFF
--- a/src/encord_active/app/auth/jwt.py
+++ b/src/encord_active/app/auth/jwt.py
@@ -30,7 +30,8 @@ def auth():
             token = token_state.value
 
         decoded = decode(token, settings.JWT_SECRET, algorithms=["HS256"])
-        assert decoded["deployment_name"] == settings.DEPLOYMENT_NAME
+        if decoded["deployment_name"] == settings.DEPLOYMENT_NAME:
+            raise ValueError("Cannot access deployment")
         st.experimental_set_query_params()
     except:
         st.error("Unauthorized")

--- a/src/encord_active/app/auth/jwt.py
+++ b/src/encord_active/app/auth/jwt.py
@@ -30,7 +30,7 @@ def auth():
             token = token_state.value
 
         decoded = decode(token, settings.JWT_SECRET, algorithms=["HS256"])
-        if decoded["deployment_name"] == settings.DEPLOYMENT_NAME:
+        if decoded["deployment_name"] != settings.DEPLOYMENT_NAME:
             raise ValueError("Cannot access deployment")
         st.experimental_set_query_params()
     except:

--- a/src/encord_active/server/dependencies.py
+++ b/src/encord_active/server/dependencies.py
@@ -25,7 +25,8 @@ async def verify_token(token: Annotated[str, Depends(oauth2_scheme)]):
 
     try:
         decoded = decode(token, settings.JWT_SECRET, algorithms=["HS256"])
-        assert decoded["deployment_name"] == settings.DEPLOYMENT_NAME
+        if decoded["deployment_name"] != settings.DEPLOYMENT_NAME:
+            raise ValueError()
     except:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/encord_active/server/dependencies.py
+++ b/src/encord_active/server/dependencies.py
@@ -26,7 +26,7 @@ async def verify_token(token: Annotated[str, Depends(oauth2_scheme)]):
     try:
         decoded = decode(token, settings.JWT_SECRET, algorithms=["HS256"])
         if decoded["deployment_name"] != settings.DEPLOYMENT_NAME:
-            raise ValueError()
+            raise ValueError("Cannot acccess deployment")
     except:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
assert is not compiled to any code when optimizations are enabled: https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement
