### PR TITLE
fix (COCO import): Assign two default object types for unknown types

### DIFF
--- a/src/encord_active/cli/utils/coco.py
+++ b/src/encord_active/cli/utils/coco.py
@@ -69,7 +69,8 @@ def import_coco_predictions(
 
         if shape.value not in category_types[res.category_id]:
             raise TypeError(
-                f"Prediction type for is in '{shape}' shape, however there is no class like this in the COCO annotations file."
+                f"Found a prediction type for category '{res.category_id}' in '{shape}' shape, "
+                f"however there is no category like this in the COCO annotation file."
             )
 
         predictions.append(

--- a/src/encord_active/cli/utils/coco.py
+++ b/src/encord_active/cli/utils/coco.py
@@ -70,8 +70,8 @@ def import_coco_predictions(
 
         if shape.value not in category_types[res.category_id]:
             raise TypeError(
-                f"Found a prediction type for category '{res.category_id}' in '{shape}' shape, "
-                f"however there is no category like this in the COCO annotation file."
+                f"Found a prediction with shape '{shape}' for the category '{res.category_id}',"
+                f"however there is no category with that shape in the ontology."
             )
 
         predictions.append(

--- a/src/encord_active/cli/utils/coco.py
+++ b/src/encord_active/cli/utils/coco.py
@@ -36,6 +36,11 @@ def import_coco_predictions(
     category_to_hash = {
         (str(int(obj["id"][:-1]) - 1), obj["shape"]): obj["featureNodeHash"] for obj in ontology["objects"]
     }
+
+    category_types = {}
+    for obj in ontology["objects"]:
+        category_types.setdefault(int(obj["id"][:-1]) - 1, []).append(obj["shape"])
+
     predictions = []
     results = json.loads(predictions_path.read_text(encoding="utf-8"))
 
@@ -61,6 +66,11 @@ def import_coco_predictions(
             data = BoundingBox(x=x, y=y, w=w, h=h)
         else:
             raise Exception("Unsupported result format")
+
+        if shape.value not in category_types[res.category_id]:
+            raise TypeError(
+                f"Prediction type for is in '{shape}' shape, however there is no class like this in the COCO annotations file."
+            )
 
         predictions.append(
             Prediction(

--- a/src/encord_active/cli/utils/coco.py
+++ b/src/encord_active/cli/utils/coco.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Dict
 
 import numpy as np
 from encord.objects.common import Shape
@@ -37,7 +38,7 @@ def import_coco_predictions(
         (str(int(obj["id"][:-1]) - 1), obj["shape"]): obj["featureNodeHash"] for obj in ontology["objects"]
     }
 
-    category_types = {}
+    category_types: Dict[int, list] = {}
     for obj in ontology["objects"]:
         category_types.setdefault(int(obj["id"][:-1]) - 1, []).append(obj["shape"])
 

--- a/src/encord_active/lib/coco/importer.py
+++ b/src/encord_active/lib/coco/importer.py
@@ -208,13 +208,13 @@ class CocoImporter:
     def create_ontology(self) -> LocalOntology:
         print(f"Creating a new ontology: {self.title}")
         ontology_structure = OntologyStructure()
-        default_category_info = CocoCategoryInfo(shapes={Shape.POLYGON})
+        # NOTE: create both polygon and bbox ontology objects when there is no way to infer the shape
+        default_category_info = CocoCategoryInfo(shapes={Shape.POLYGON, Shape.BOUNDING_BOX})
         for cat in self.categories:
-            # NOTE: default to polygon when there is no way to infer the shape
             category_info = self.category_shapes.get(cat.id_, default_category_info)
             shapes = category_info.shapes
             for i, shape in enumerate(shapes):
-                # NOTE: add one the the category id to avoid index 0
+                # NOTE: add one to the category id to avoid index 0
                 new_id = (cat.id_ + 1) * 10 + i
                 self.id_mappings[(cat.id_, shape)] = new_id
                 name = f"{cat.name}-{shape.value}" if len(shapes) > 1 else cat.name

--- a/src/encord_active/lib/coco/importer.py
+++ b/src/encord_active/lib/coco/importer.py
@@ -217,7 +217,7 @@ class CocoImporter:
                 # NOTE: add one to the category id to avoid index 0
                 new_id = (cat.id_ + 1) * 10 + i
                 self.id_mappings[(cat.id_, shape)] = new_id
-                name = f"{cat.name} ({shape.value})" if len(shapes) > 1 else cat.name
+                name = cat.name
                 ontology_structure.add_object(name=name, shape=shape, uid=new_id)
 
         ontology: LocalOntology = self.user_client.create_ontology(

--- a/src/encord_active/lib/coco/importer.py
+++ b/src/encord_active/lib/coco/importer.py
@@ -217,7 +217,7 @@ class CocoImporter:
                 # NOTE: add one to the category id to avoid index 0
                 new_id = (cat.id_ + 1) * 10 + i
                 self.id_mappings[(cat.id_, shape)] = new_id
-                name = f"{cat.name}-{shape.value}" if len(shapes) > 1 else cat.name
+                name = f"{cat.name} ({shape.value})" if len(shapes) > 1 else cat.name
                 ontology_structure.add_object(name=name, shape=shape, uid=new_id)
 
         ontology: LocalOntology = self.user_client.create_ontology(


### PR DESCRIPTION
This PR fixes two issues:
- When a class in category is not exist in annotations, the default type was polygon, which leads to an error if the actual type is bbox in predictions.
- If the prediction shape type is different from the original COCO category type, we raise an error and show a message that reports the problem. 