### PR TITLE
chore(import data): optimize by utilizing available image metadata when feasible

### DIFF
--- a/src/encord_active/lib/common/data_utils.py
+++ b/src/encord_active/lib/common/data_utils.py
@@ -53,33 +53,36 @@ def extract_frames(video_file_name: Path, img_dir: Path, data_hash: str, symlink
 def _extract_frames(video_file_name: Path, img_dir: Path, data_hash: str) -> None:
     # DENIS: for the rest to work, I will need to throw if the current directory exists and give a nice user warning.
     img_dir.mkdir(parents=True, exist_ok=True)
-    command = f"ffmpeg -i {video_file_name} -start_number 0 {img_dir}/{data_hash}_%d.png -hide_banner"
+    command = f'ffmpeg -i "{video_file_name}" -start_number 0 {img_dir}/{data_hash}_%d.png -hide_banner'
     if subprocess.run(command, shell=True, capture_output=True, stdout=None, check=False).returncode != 0:
         raise RuntimeError(
-            "Splitting videos into multiple image files failed. Please ensure that you have FFMPEG "
-            f"installed on your machine: https://ffmpeg.org/download.html The comamand that failed was `{command}`."
+            "Failed to split the video into multiple image files. Please ensure that you have FFMPEG "
+            f"installed on your machine. You can download it from https://ffmpeg.org/download.html. "
+            f" The command that failed was: `{command}`."
         )
 
 
 def count_frames(video_file_name: Path) -> int:
-    command = f"ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of csv=p=0 {video_file_name}"
+    command = f'ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of csv=p=0 "{video_file_name}"'
     output = subprocess.run(command, shell=True, capture_output=True, stdout=None, check=False)
     if output.returncode != 0:
         raise RuntimeError(
-            "Counting the number of frames in a video has failed. Please ensure that you have FFMPEG "
-            f"installed on your machine: https://ffmpeg.org/download.html The comamand that failed was `{command}`."
+            "Failed to count the number of frames in the video. Please ensure that you have FFMPEG "
+            "installed on your machine. You can download it from https://ffmpeg.org/download.html. "
+            f"The command that failed was: `{command}`."
         )
     output_str = output.stdout.decode("utf-8")
     return int(output_str)
 
 
 def get_frames_per_second(video_file_name: Path) -> float:
-    command = f'ffmpeg -i {video_file_name} 2>&1 | sed -n "s/.*, \\(.*\\) fp.*/\\1/p"'
+    command = f'ffmpeg -i "{video_file_name}" 2>&1 | sed -n "s/.*, \\(.*\\) fp.*/\\1/p"'
     output = subprocess.run(command, shell=True, capture_output=True, stdout=None, check=False)
     if output.returncode != 0:
         raise RuntimeError(
-            "Counting the frame rate in a video has failed. Please ensure that you have FFMPEG "
-            f"installed on your machine: https://ffmpeg.org/download.html The comamand that failed was `{command}`."
+            "Failed to count the frame rate in the video. Please ensure that you have FFMPEG "
+            f"installed on your machine. You can download it from https://ffmpeg.org/download.html. "
+            f"The command that failed was: `{command}`."
         )
     output_str = output.stdout.decode("utf-8")
     return float(output_str)

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -269,6 +269,11 @@ class Project:
 
         # Download new project data
         if len(label_rows_to_download) > 0:
+            operation_description = "Collecting the new data"
+            store_data_locally: bool = project_file_structure.load_project_meta().get("store_data_locally", False)
+            if not store_data_locally:
+                operation_description = "Collecting information on the new data"
+
             with PrismaConnection(project_file_structure) as conn:
                 with conn.batch_() as batch:
                     downloaded_label_rows = collect_async(
@@ -279,7 +284,7 @@ class Project:
                             batch=batch,
                         ),
                         label_rows_to_download,
-                        desc="Collecting new data",
+                        desc=operation_description,
                     )
                     batch.commit()
         else:

--- a/src/encord_active/lib/project/project.py
+++ b/src/encord_active/lib/project/project.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     import prisma
+    from prisma.types import DataUnitUpsertInput
 
 import yaml
 from encord import Project as EncordProject
@@ -25,7 +26,6 @@ from encord_active.lib.common.data_utils import (
     collect_async,
     count_frames,
     download_file,
-    download_image,
     extract_frames,
     file_path_to_url,
     get_frames_per_second,
@@ -360,10 +360,8 @@ def download_data(
         width = du["width"]
         height = du["height"]
 
-        # State the compound key representing the data unit in the db
-        query_where_input = {"data_hash_frame": {"data_hash": data_hash, "frame": frame}}
         # State what data is going to be created / updated in the db upsert
-        query_data_input = {
+        query_data_input: DataUnitUpsertInput = {
             "create": {
                 "data_hash": data_hash,
                 "data_title": du["data_title"],
@@ -395,7 +393,12 @@ def download_data(
             # The online version doesn't require any additional content, except for the image url,
             # which is not a permalink so best not to add it.
             pass
-        batch.dataunit.upsert(where=query_where_input, data=query_data_input)
+
+        batch.dataunit.upsert(
+            # State the compound key representing the data unit in the db
+            where={"data_hash_frame": {"data_hash": data_hash, "frame": frame}},
+            data=query_data_input,
+        )
 
 
 def download_label_row_and_data(


### PR DESCRIPTION
Added some actions at the `import data` step to avoid downloading/opening images unless it's necessary.
Passed the burden of downloading the images on online projects to the metrics management, when they actually require such download.

Also, made a quick fix to accept `videos` with whitespacing in their naming.