### PR TITLE
fix: reset filters on scope change

### DIFF
--- a/frontend_components/encord_active_components/frontend/src/components/explorer/Explorer.tsx
+++ b/frontend_components/encord_active_components/frontend/src/components/explorer/Explorer.tsx
@@ -275,13 +275,13 @@ export const Explorer = ({
     similarItems?.length ||
     !isEmpty(filters.range) ||
     !isEmpty([...filters.tags?.data, ...filters.tags?.label]);
-  const reset = () => (
-    setItemSet(new Set()),
-    setSearch(undefined),
-    setSimilarityItem(null),
-    setNewFilters(DefaultFilters),
-    setPage(1)
-  );
+  const reset = (clearFilters: boolean = true) => {
+    setItemSet(new Set());
+    setSearch(undefined);
+    setSimilarityItem(null);
+    if (clearFilters) setNewFilters(DefaultFilters);
+    setPage(1);
+  };
 
   const itemsToRender =
     similarItems ?? searchResults?.ids ?? withSortOrder.map(({ id }) => id);
@@ -314,7 +314,7 @@ export const Explorer = ({
           scopedMetricNames.includes(newMetric.name),
       )!;
     if (usedScopes.length !== 1) {
-      reset();
+      reset(false);
     }
     setSelectedMetric(newMetric);
   };

--- a/frontend_components/encord_active_components/frontend/src/components/explorer/Explorer.tsx
+++ b/frontend_components/encord_active_components/frontend/src/components/explorer/Explorer.tsx
@@ -279,7 +279,8 @@ export const Explorer = ({
     setItemSet(new Set()),
     setSearch(undefined),
     setSimilarityItem(null),
-    setNewFilters(DefaultFilters)
+    setNewFilters(DefaultFilters),
+    setPage(1)
   );
 
   const itemsToRender =
@@ -302,6 +303,21 @@ export const Explorer = ({
     closePreview(), setPage(1), setSimilarityItem(itemId)
   );
   const totalMetricsCount = metrics ? Object.values(metrics).flat().length : 0;
+  const onMetricSelected = (newMetric: Metric) => {
+    if (!metrics || !selectedMetric) return;
+
+    const usedScopes = Object.entries(metrics)
+      .map(([_, scopedMetrics]) => scopedMetrics.map((metric) => metric.name))
+      .filter(
+        (scopedMetricNames) =>
+          scopedMetricNames.includes(selectedMetric.name) ||
+          scopedMetricNames.includes(newMetric.name),
+      )!;
+    if (usedScopes.length !== 1) {
+      reset();
+    }
+    setSelectedMetric(newMetric);
+  };
 
   useEffect(() => {
     if (!selectedMetric && metrics && totalMetricsCount > 0)
@@ -419,9 +435,7 @@ export const Explorer = ({
                 <label className="input-group  w-auto">
                   <select
                     onChange={(event) =>
-                      setSelectedMetric(
-                        JSON.parse(event.target.value) as Metric,
-                      )
+                      onMetricSelected(JSON.parse(event.target.value) as Metric)
                     }
                     className="select select-bordered focus:outline-none"
                     disabled={!!similarItems?.length}


### PR DESCRIPTION
When filtering data on a "data metric" and then selecting a "label metric", explorer would be empty.
Now, when scope changes, filters will be cleared. 

One side-effect is that the pagination will be set to page one - which also didn't happen on reset previously.