### PR TITLE
fix: bug - add explicit order by

### DIFF
--- a/src/encord_active/server/routers/queries/metric_query.py
+++ b/src/encord_active/server/routers/queries/metric_query.py
@@ -139,19 +139,31 @@ def query_metric_attr_summary(
         }
     metric_q1 = (
         sess.exec(
-            select(metric_attr).where(*where, is_not(metric_attr, None)).offset(metric_count // 4).limit(1)
+            select(metric_attr)
+            .where(*where, is_not(metric_attr, None))
+            .offset(metric_count // 4)
+            .order_by(metric_attr)
+            .limit(1)
         ).first()
         or 0
     )
     metric_q2 = (
         sess.exec(
-            select(metric_attr).where(*where, is_not(metric_attr, None)).offset(metric_count // 2).limit(1)
+            select(metric_attr)
+            .where(*where, is_not(metric_attr, None))
+            .offset(metric_count // 2)
+            .order_by(metric_attr)
+            .limit(1)
         ).first()
         or 0
     )
     metric_q3 = (
         sess.exec(
-            select(metric_attr).where(*where, is_not(metric_attr, None)).offset((metric_count * 3) // 4).limit(1)
+            select(metric_attr)
+            .where(*where, is_not(metric_attr, None))
+            .offset((metric_count * 3) // 4)
+            .order_by(metric_attr)
+            .limit(1)
         ).first()
         or 0
     )


### PR DESCRIPTION
This was working due to sqlite selecting the index by default, but adding the explicit order by is needed for proper correctness. (Backport from feat/no-disk).